### PR TITLE
Add column name for agency_name in return data

### DIFF
--- a/resources/DataSources.py
+++ b/resources/DataSources.py
@@ -85,6 +85,7 @@ class DataSources(Resource):
             cursor.execute(sql_query)
             results = cursor.fetchall()
 
+            approved_columns.append('agency_name')
             data_source_matches = [dict(zip(approved_columns, result)) for result in results]
 
             for item in data_source_matches:


### PR DESCRIPTION
#### Fixes

* Add missing "agency_name" column to for the data_source_matches returned

#### Description
The Data Sources route was getting the agency_name value, but it wasn't included as a column in the data returned to the client. 