### PR TITLE
add pagination for agencies

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ api.add_resource(User, '/user', resource_class_kwargs={'psycopg2_connection': ps
 api.add_resource(QuickSearch, '/quick-search/<search>/<location>', resource_class_kwargs={'psycopg2_connection': psycopg2_connection})
 api.add_resource(Archives, '/archives', resource_class_kwargs={'psycopg2_connection': psycopg2_connection})
 api.add_resource(DataSources, '/data-sources', resource_class_kwargs={'psycopg2_connection': psycopg2_connection})
-api.add_resource(Agencies, '/agencies', resource_class_kwargs={'psycopg2_connection': psycopg2_connection})
+api.add_resource(Agencies, '/agencies/<page>', resource_class_kwargs={'psycopg2_connection': psycopg2_connection})
 
 if __name__ == '__main__':
     app.run(debug=True, host="0.0.0.0")

--- a/resources/Agencies.py
+++ b/resources/Agencies.py
@@ -37,11 +37,12 @@ class Agencies(Resource):
          self.psycopg2_connection = kwargs['psycopg2_connection']
     
     @api_required 
-    def get(self):
+    def get(self, page):
         try:
             cursor = self.psycopg2_connection.cursor()
             joined_column_names = ", ".join(approved_columns)
-            cursor.execute(f"select {joined_column_names} from agencies where approved = 'TRUE'")
+            offset = (int(page) - 1) * 1000
+            cursor.execute(f"select {joined_column_names} from agencies where approved = 'TRUE' limit 1000 offset {offset}")
             results = cursor.fetchall()
             agencies_matches = [dict(zip(approved_columns, result)) for result in results]
 


### PR DESCRIPTION
#### Fixes

* Add pagination to agencies endpoint

#### Description

* Limits each request to the agencies endpoint to 1000 and requires a "page" parameter which can be used to get more results in further requests

#### Docs

* Will update Gitbook with instructions on pagination usage