### PR TITLE
Add ability to get API key directly from user

### DIFF
--- a/middleware/security.py
+++ b/middleware/security.py
@@ -39,7 +39,7 @@ def api_required(func):
                     payload = jwt.decode(token, os.getenv('SECRET_KEY'), algorithms=['HS256'])
                     api_key = payload['api_key']
                 except jwt.InvalidTokenError:
-                    return {"message": 'Invalid token.'}, 400
+                    api_key = request.headers['Authorization'].split(" ")[1]
                 if api_key == "undefined":
                     return {"message": "Please provide an API key"}, 400
             else:


### PR DESCRIPTION
#### Fixes

* Enable API to accept a JWT token or API key for authorization

#### Description
I added a check for an API key if there's an error raised for the JWT token decoder.