### PR TITLE
final launch refinements → dev

### DIFF
--- a/client/src/components/SearchResultCard.vue
+++ b/client/src/components/SearchResultCard.vue
@@ -101,8 +101,9 @@
 		</p>
 		<div class="mt-auto flex flex-col">
 			<Button
-				@click="openSource"
-				class="text-lg font-medium px-4 py-1 mt-4 mb-2 lg:mx-0 max-w-full"
+				:class="['text-lg font-medium px-4 py-1 mt-4 mb-2 lg:mx-0 max-w-full']"
+				:disabled="!dataSource.source_url || dataSource.url_status === 'broken' || dataSource.url_status === 'not found'"
+				@click="dataSource.source_url && dataSource.url_status !== 'broken' && dataSource.url_status !== 'not found' ? openSource() : null"
 				data-test="search-result-source-button"
 			>
 				Visit data source <i class="fa fa-external-link"></i>

--- a/client/src/components/SearchResultCard.vue
+++ b/client/src/components/SearchResultCard.vue
@@ -108,6 +108,7 @@
 			>
 				Visit data source <i class="fa fa-external-link"></i>
 			</Button>
+<!-- we'll put this back once we close #151 and #150 in this repo
 			<Button
 				@click="showDetails"
 				intent="secondary"
@@ -116,6 +117,7 @@
 			>
 				View details
 			</Button>
+-->
 		</div>
 	</GridItem>
 </template>


### PR DESCRIPTION
- removes button to view data source details (#151)
- dims "view source url" button if a source has no URL or url_status is `none found` or `broken`