### PR TITLE
base URL envar name

### DIFF
--- a/client/src/pages/DataSourceStaticView.vue
+++ b/client/src/pages/DataSourceStaticView.vue
@@ -113,7 +113,7 @@ export default {
 			const headers = { Authorization: `Bearer ${process.env.VUE_APP_PDAP_TOKEN}` };
 			try {
 				const res = await axios.get(
-					`${process.env.VUE_APP_BASE_URL}/search-tokens?endpoint=data-sources-by-id&arg1=${this.id}`,
+					`${process.env.VITE_VUE_APP_BASE_URL}/search-tokens?endpoint=data-sources-by-id&arg1=${this.id}`,
 					{ headers }
 				);
 				this.dataSource = res.data;

--- a/resources/SearchTokens.py
+++ b/resources/SearchTokens.py
@@ -11,7 +11,7 @@ from flask import request, jsonify
 from middleware.data_source_queries import data_source_by_id_query, data_sources_query
 from middleware.quick_search_query import quick_search_query
 
-BASE_URL = os.getenv("VUE_APP_BASE_URL")
+BASE_URL = os.getenv("VITE_VUE_APP_BASE_URL")
 
 
 class SearchTokens(Resource):


### PR DESCRIPTION
found two instances of `VUE_APP_BASE_URL` when we should now be using `VITE_VUE_APP_BASE_URL` (I think)