### PR TITLE
feat(router): add logic to router to handle meta tags

### DIFF
--- a/client/src/router.js
+++ b/client/src/router.js
@@ -8,10 +8,16 @@ import QuickSearchPage from '../src/pages/QuickSearchPage.vue';
 import ResetPassword from './pages/ResetPassword.vue';
 import SearchResultPage from '../src/pages/SearchResultPage.vue';
 
-export const PRIVATE_ROUTES = ['/change-password'];
+import acronym from 'pdap-design-system/images/acronym.svg';
 
 const routes = [
-	{ path: '/', component: QuickSearchPage, name: 'QuickSearchPage' },
+	{
+		path: '/',
+		component: QuickSearchPage,
+		name: 'QuickSearchPage',
+		// Use meta property on route to override meta tag defaults
+		// meta: { title: 'Police Data Accessibility Project - Search', metaTags: [{ property: 'og:title', title: 'Police Data Accessibility Project - Search' }] },
+	},
 	{
 		path: '/search/:searchTerm/:location',
 		component: SearchResultPage,
@@ -45,13 +51,66 @@ const router = createRouter({
 });
 
 router.beforeEach(async (to) => {
+	// Update meta tags per route
+	refreshMetaTagsByRoute(to);
+
 	// redirect to login page if not logged in and trying to access a restricted page
 	const auth = useAuthStore();
-
 	if (PRIVATE_ROUTES.includes(to.fullPath) && !auth.userId) {
 		auth.returnUrl = to.path;
 		router.push('/login');
 	}
 });
+
+// Util
+export const PRIVATE_ROUTES = ['/change-password'];
+
+const DEFAULT_META_TAGS = new Map([
+	[
+		'description',
+		'Data and tools for answering questions about any police system in the United States',
+	],
+	['title', 'Police Data Accessibility Project'],
+	[
+		'og:description',
+		'Data and tools for answering questions about any police system in the United States',
+	],
+	['og:title', 'Police Data Accessibility Project'],
+	['og:type', 'website'],
+	['og:site_name', 'PDAP'],
+	['og:image', acronym],
+]);
+const META_PROPERTIES = [...DEFAULT_META_TAGS.keys(), 'og:url'];
+
+/**
+ * Adds meta tags by route
+ * @param {RouteLocationNormalized} to Vue router route location
+ */
+function refreshMetaTagsByRoute(to) {
+	document.title = to.meta.title ?? DEFAULT_META_TAGS.get('title');
+	Array.from(document.querySelectorAll('[data-vue-router-controlled]')).map(
+		(el) => el.parentNode.removeChild(el),
+	);
+
+	META_PROPERTIES.filter((prop) => prop !== 'title')
+		.map((prop) => {
+			const tagInRouteMetaData = to?.meta?.metaTags?.find(
+				(tag) => tag.property === prop,
+			);
+			const content =
+				prop === 'og:url'
+					? `${import.meta.env.VITE_VUE_APP_BASE_URL}${to.fullPath}`
+					: tagInRouteMetaData
+						? tagInRouteMetaData
+						: DEFAULT_META_TAGS.get(prop);
+
+			const tag = document.createElement('meta');
+			tag.setAttribute('property', prop);
+			tag.setAttribute('content', content);
+			tag.setAttribute('data-vue-router-controlled', '');
+			return tag;
+		})
+		.forEach((tag) => document.head.appendChild(tag));
+}
 
 export default router;

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -27,9 +27,6 @@ const routes = [
 		path: '/search/:searchTerm/:location',
 		component: SearchResultPage,
 		name: 'SearchResultPage',
-		meta: {
-			metaTags: [{ property: 'og:type', content: 'test' }],
-		},
 	},
 	{
 		path: '/data-sources/:id',
@@ -120,12 +117,18 @@ function refreshMetaTagsByRoute(to) {
 			const tagInRouteMetaData = nearestRouteWithMeta?.meta?.metaTags?.find(
 				(tag) => tag.property === prop,
 			);
-			const content =
-				prop === 'og:url'
-					? `${import.meta.env.VITE_VUE_APP_BASE_URL}${to.fullPath}`
-					: tagInRouteMetaData
-						? tagInRouteMetaData.content
-						: DEFAULT_META_TAGS.get(prop);
+
+			let content;
+			switch (true) {
+				case prop === 'og:url':
+					content = `${import.meta.env.VITE_VUE_APP_BASE_URL}${to.fullPath}`;
+					break;
+				case Boolean(tagInRouteMetaData):
+					content = tagInRouteMetaData.content;
+					break;
+				default:
+					content = DEFAULT_META_TAGS.get(prop);
+			}
 
 			const tag = document.createElement('meta');
 			tag.setAttribute(prop.includes(':') ? 'property' : 'name', prop);

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -97,18 +97,22 @@ const META_PROPERTIES = [...DEFAULT_META_TAGS.keys(), 'og:url'];
  * @param {RouteLocationNormalized} to Vue router route location
  */
 function refreshMetaTagsByRoute(to) {
+	// Get nearest matched route that has title / meta tag overrides
 	const nearestRouteWithTitle = [...to.matched]
 		.reverse()
-		.find((r) => r.meta && r.meta.title);
+		.find((route) => route?.meta?.title);
 
 	const nearestRouteWithMeta = [...to.matched]
 		.reverse()
-		.find((r) => r.meta && r.meta.metaTags);
+		.find((route) => route?.meta?.metaTags);
 
+	// Update document title
 	document.title =
 		nearestRouteWithTitle?.meta?.title ?? DEFAULT_META_TAGS.get('title');
-	Array.from(document.querySelectorAll('[data-controlled-meta]')).map((el) =>
-		el.parentNode.removeChild(el),
+
+	// Update meta tags
+	Array.from(document.querySelectorAll('[data-controlled-meta]')).forEach(
+		(el) => el.parentNode.removeChild(el),
 	);
 
 	META_PROPERTIES.filter((prop) => prop !== 'title')


### PR DESCRIPTION
Will handle #199 when merged.

## To test
Run the app, visit several different routes, ensure that the tags change as expected per route (only the `og:url` tag will change for now, but we can use the `meta` property on the routes object to update others if need be)