### PR TITLE
Rename id to user_id, matching parameter name.

### DIFF
--- a/middleware/login_queries.py
+++ b/middleware/login_queries.py
@@ -61,7 +61,7 @@ def create_session_token(cursor: PgCursor, user_id: int, email: str) -> str:
     payload = {
         "exp": expiration,
         "iat": datetime.datetime.utcnow(),
-        "sub": id,
+        "sub": user_id,
     }
     session_token = jwt.encode(payload, os.getenv("SECRET_KEY"), algorithm="HS256")
     cursor.execute(


### PR DESCRIPTION
#### Fixes

* #230

#### Description

* Likely a product of my earlier refactorings, the parameter `user_id` was not being passed to the `sub` entry in `create_session_token()` -- instead, `id` was used, which is a specific python function. This has been corrected.

#### Testing

* Run app_test.py, with `SECRET_ENV` environment key properly filled in.