### PR TITLE
Mc fix type hinting bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Then run the following command to create a virtual environment:
 
 ```
 
-virtualenv -p python3.9 venv
+virtualenv -p python3.11 venv
 
 ```
 

--- a/middleware/data_source_queries.py
+++ b/middleware/data_source_queries.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any, Optional, Tuple
+from typing import List, Dict, Any, Optional, Tuple, Union
 from utilities.common import convert_dates_to_strings, format_arrays
 from psycopg2.extensions import connection as PgConnection
 
@@ -75,7 +75,7 @@ AGENCY_APPROVED_COLUMNS = [
 
 def data_source_by_id_results(
     conn: PgConnection, data_source_id: str
-) -> tuple[Any, ...] | None:
+) -> Union[tuple[Any, ...], None]:
     """
     Fetches a single data source by its ID, including related agency information, from a PostgreSQL database.
 


### PR DESCRIPTION
#### Fixes

* Bug reported in PR #228 where type hinting caused error on pre-3.10 versions of Python.

#### Description

* Replaces `|` type hint with `Union` type hint.

#### Testing

* Run app to confirm functionality on pre-3.10 version of Python.