### PR TITLE
Implement docstring checks and Python checks

### DIFF
--- a/.github/scripts/comment_pr.py
+++ b/.github/scripts/comment_pr.py
@@ -1,0 +1,22 @@
+import os
+import json
+import requests
+
+
+def post_comment(issue_number, repo_token, message):
+    url = f"https://api.github.com/repos/{os.getenv('GITHUB_REPOSITORY')}/issues/{issue_number}/comments"
+    headers = {"Authorization": f"token {repo_token}"}
+    data = {"body": message}
+    response = requests.post(url, headers=headers, data=json.dumps(data))
+    response.raise_for_status()
+
+
+issue_number = os.getenv("GITHUB_REF").split("/")[-2]
+repo_token = os.getenv("GITHUB_TOKEN")
+
+# Assume you've saved the outputs to files
+mypy_result = open("mypy_output.txt").read().strip()
+pydocstyle_result = open("pydocstyle_output.txt").read().strip()
+
+comment = f"## Type Hinting and Docstring Checks\n\n### mypy\n```\n{mypy_result}\n```\n### pydocstyle\n```\n{pydocstyle_result}\n```"
+post_comment(issue_number, repo_token, comment)

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -1,0 +1,55 @@
+name: Python Checks
+
+on: [pull_request]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  type_and_docstring_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Fetch base and head branches
+      run: |
+        git fetch --no-tags --depth=1 origin +${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+        git fetch --no-tags --depth=1 origin +${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install mypy pydocstyle requests types-requests
+
+    - name: Find modified Python files
+      run: |
+        echo "MODIFIED_FILES<<EOF" >> $GITHUB_ENV
+        git diff --name-only refs/remotes/origin/${{ github.base_ref }} $(git merge-base refs/remotes/origin/${{ github.base_ref }} refs/remotes/origin/${{ github.head_ref }}) | grep '\.py$' >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+
+    - name: Run mypy and save output
+      if: env.MODIFIED_FILES != ''
+      run: |
+        echo "${{ env.MODIFIED_FILES }}" | xargs mypy --ignore-missing-imports --disallow-untyped-defs > mypy_output.txt 2>&1
+      continue-on-error: true
+
+    - name: Run pydocstyle and save output
+      if: env.MODIFIED_FILES != ''
+      run: |
+        echo "${{ env.MODIFIED_FILES }}" | xargs pydocstyle > pydocstyle_output.txt 2>&1
+      continue-on-error: true
+
+    - name: Set script permissions
+      run: chmod +x .github/scripts/comment_pr.py
+
+    - name: Comment PR
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: python .github/scripts/comment_pr.py

--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,0 +1,3 @@
+[pydocstyle]
+match = .*\.py
+ignore = D200, D205, D212, D400, D404, D415


### PR DESCRIPTION
#### Fixes

* #213

#### Description

* Implemented docstring checks through pydocstyle and added Python checks in Github Actions. 
* The Python checks include running `mypy` and `pydocstyle` on modified Python files and commenting the output on the associated pull request.
* It is designed to only run on files that have been modified in the pull request.

#### Testing

Testing has already been demonstrated in the following PRs:
* [This PR](https://github.com/maxachis/Github-Action-Test/pull/1#issuecomment-2043748474), which (after a few modifications) showcases how it would work on a PR
* [This other PR](https://github.com/maxachis/Github-Action-Test/pull/2), which shows it functioning again, but now _only on the new file I've created_. The other file, despite not being corrected, is not checked -- it only runs these checks on files that have been modified.


#### Performance

* This Github action is quite light, consistently running in under 30 seconds.