### PR TITLE
Add timeout to `requests` calls

### DIFF
--- a/.github/scripts/comment_pr.py
+++ b/.github/scripts/comment_pr.py
@@ -42,7 +42,7 @@ def post_comment(issue_number: str, repo_token: str, message: str) -> None:
     url = f"https://api.github.com/repos/{os.getenv('GITHUB_REPOSITORY')}/issues/{issue_number}/comments"
     headers = {"Authorization": f"token {repo_token}"}
     data = {"body": message}
-    response = requests.post(url, headers=headers, data=json.dumps(data))
+    response = requests.post(url, headers=headers, data=json.dumps(data), timeout=60)
     response.raise_for_status()
 
 

--- a/regular_api_checks.py
+++ b/regular_api_checks.py
@@ -14,7 +14,7 @@ def test_quicksearch_officer_involved_shootings_philadelphia_results():
         f"{BASE_URL}/quick-search/Officer Involved Shootings/philadelphia",
         headers=HEADERS,
         json={"test_flag": True},
-    )
+    timeout=60)
 
     return len(response.json()["data"]) > 0
 
@@ -24,7 +24,7 @@ def test_quicksearch_officer_involved_shootings_lowercase_philadelphia_results()
         f"{BASE_URL}/quick-search/officer involved shootings/Philadelphia",
         headers=HEADERS,
         json={"test_flag": True},
-    )
+    timeout=60)
 
     return len(response.json()["data"]) > 0
 
@@ -34,7 +34,7 @@ def test_quicksearch_officer_involved_shootings_philadelphia_county_results():
         f"{BASE_URL}/quick-search/Officer Involved Shootings/philadelphia county",
         headers=HEADERS,
         json={"test_flag": True},
-    )
+    timeout=60)
 
     return len(response.json()["data"]) > 0
 
@@ -44,7 +44,7 @@ def test_quicksearch_all_allgeheny_results():
         f"{BASE_URL}/quick-search/all/allegheny",
         headers=HEADERS,
         json={"test_flag": True},
-    )
+    timeout=60)
 
     return len(response.json()["data"]) > 0
 
@@ -54,7 +54,7 @@ def test_quicksearch_complaints_all_results():
         f"{BASE_URL}/quick-search/complaints/all",
         headers=HEADERS,
         json={"test_flag": True},
-    )
+    timeout=60)
 
     return len(response.json()["data"]) > 0
 
@@ -64,7 +64,7 @@ def test_quicksearch_media_bulletin_pennsylvania_results():
         f"{BASE_URL}/quick-search/media bulletin/pennsylvania",
         headers=HEADERS,
         json={"test_flag": True},
-    )
+    timeout=60)
 
     return len(response.json()["data"]) > 0
 
@@ -74,13 +74,13 @@ def test_data_source_by_id():
     response = requests.get(
         f"{BASE_URL}/data-sources-by-id/reczwxaH31Wf9gRjS",
         headers=HEADERS,
-    )
+    timeout=60)
 
     return len(response.json()["data"]) > 0
 
 
 def test_data_sources():
-    response = requests.get(f"{BASE_URL}/data-sources", headers=HEADERS)
+    response = requests.get(f"{BASE_URL}/data-sources", headers=HEADERS, timeout=60)
 
     return len(response.json()["data"]) > 0
 
@@ -90,7 +90,7 @@ def test_create_data_source():
         f"{BASE_URL}/data-sources",
         headers=HEADERS,
         json={"name": "test", "record_type": "test"},
-    )
+    timeout=60)
 
     assert response.json() == True
 
@@ -100,13 +100,13 @@ def test_update_data_source():
         f"{BASE_URL}/data-sources-by-id/45a4cd5d-26da-473a-a98e-a39fbcf4a96c",
         headers=HEADERS,
         json={"description": "test"},
-    )
+    timeout=60)
 
     assert response.json()["message"] == "Data source updated successfully."
 
 
 def test_data_sources_approved():
-    response = requests.get(f"{BASE_URL}/data-sources", headers=HEADERS)
+    response = requests.get(f"{BASE_URL}/data-sources", headers=HEADERS, timeout=60)
     unapproved_url = "https://joinstatepolice.ny.gov/15-mile-run"
 
     return (
@@ -119,28 +119,28 @@ def test_data_source_by_id_approved():
     response = requests.get(
         f"{BASE_URL}/data-sources-by-id/rec013MFNfBnrTpZj",
         headers=HEADERS,
-    )
+    timeout=60)
 
     return response.json() == "Data source not found."
 
 
 def test_data_sources_map():
-    response = requests.get(f"{BASE_URL}/data-sources-map", headers=HEADERS)
+    response = requests.get(f"{BASE_URL}/data-sources-map", headers=HEADERS, timeout=60)
 
     return len(response.json()["data"]) > 0
 
 
 # search-tokens
 def test_search_tokens_data_sources():
-    response = requests.get(f"{BASE_URL}/search-tokens?endpoint=data-sources")
+    response = requests.get(f"{BASE_URL}/search-tokens?endpoint=data-sources", timeout=60)
 
     return len(response.json()["data"]) > 0
 
 
 def test_search_tokens_data_source_by_id():
     response = requests.get(
-        f"{BASE_URL}/search-tokens?endpoint=data-sources-by-id&arg1=reczwxaH31Wf9gRjS"
-    )
+        f"{BASE_URL}/search-tokens?endpoint=data-sources-by-id&arg1=reczwxaH31Wf9gRjS", 
+    timeout=60)
 
     return response.json()["data_source_id"] == "reczwxaH31Wf9gRjS"
 
@@ -149,7 +149,7 @@ def test_search_tokens_quick_search_complaints_allegheny_results():
     response = requests.get(
         f"{BASE_URL}/search-tokens?endpoint=quick-search&arg1=complaints&arg2=allegheny",
         json={"test_flag": True},
-    )
+    timeout=60)
 
     return len(response.json()["data"]) > 0
 
@@ -160,7 +160,7 @@ def test_put_user():
         f"{BASE_URL}/user",
         headers=HEADERS,
         json={"email": "test2", "password": "test"},
-    )
+    timeout=60)
 
     return response.json()["message"] == "Successfully updated password"
 
@@ -170,7 +170,7 @@ def test_login():
     response = requests.post(
         f"{BASE_URL}/login",
         json={"email": "test2", "password": "test"},
-    )
+    timeout=60)
 
     return response.json()["message"] == "Successfully logged in"
 
@@ -180,12 +180,12 @@ def test_refresh_session():
     response = requests.post(
         f"{BASE_URL}/login",
         json={"email": "test2", "password": "test"},
-    )
+    timeout=60)
     token = response.json()["data"]
 
     response = requests.post(
-        f"{BASE_URL}/refresh-session", json={"session_token": token}
-    )
+        f"{BASE_URL}/refresh-session", json={"session_token": token}, 
+    timeout=60)
 
     return response.json()["message"] == "Successfully refreshed session token"
 
@@ -196,13 +196,13 @@ def test_request_reset_password():
         f"{BASE_URL}/request-reset-password",
         headers=HEADERS,
         json={"email": "test2"},
-    )
+    timeout=60)
 
     response = requests.post(
         f"{BASE_URL}/reset-password",
         headers=HEADERS,
         json={"token": reset_token.json()["token"], "password": "test"},
-    )
+    timeout=60)
 
     return response.json()["message"] == "Successfully updated password"
 
@@ -212,13 +212,13 @@ def test_reset_token_validation():
         f"{BASE_URL}/request-reset-password",
         headers=HEADERS,
         json={"email": "test2"},
-    )
+    timeout=60)
 
     response = requests.post(
         f"{BASE_URL}/reset-token-validation",
         headers=HEADERS,
         json={"token": reset_token.json()["token"], "password": "test"},
-    )
+    timeout=60)
 
     return response.json()["message"] == "Token is valid"
 
@@ -229,14 +229,14 @@ def test_get_api_key():
         f"{BASE_URL}/api_key",
         headers=HEADERS,
         json={"email": "test2", "password": "test"},
-    )
+    timeout=60)
 
     return len(response.json()["api_key"]) > 0
 
 
 # archives
 def test_get_archives():
-    response = requests.get(f"{BASE_URL}/archives", headers=HEADERS)
+    response = requests.get(f"{BASE_URL}/archives", headers=HEADERS, timeout=60)
 
     return len(response.json()[0]) > 0
 
@@ -254,7 +254,7 @@ def test_put_archives():
                 "broken_source_url_as_of": "",
             }
         ),
-    )
+    timeout=60)
 
     return response.json()["status"] == "success"
 
@@ -272,21 +272,21 @@ def test_put_archives_brokenasof():
                 "broken_source_url_as_of": datetime_string,
             }
         ),
-    )
+    timeout=60)
 
     return response.json()["status"] == "success"
 
 
 # agencies
 def test_agencies():
-    response = requests.get(f"{BASE_URL}/agencies/1", headers=HEADERS)
+    response = requests.get(f"{BASE_URL}/agencies/1", headers=HEADERS, timeout=60)
 
     return len(response.json()["data"]) > 0
 
 
 def test_agencies_pagination():
-    response1 = requests.get(f"{BASE_URL}/agencies/1", headers=HEADERS)
-    response2 = requests.get(f"{BASE_URL}/agencies/2", headers=HEADERS)
+    response1 = requests.get(f"{BASE_URL}/agencies/1", headers=HEADERS, timeout=60)
+    response2 = requests.get(f"{BASE_URL}/agencies/2", headers=HEADERS, timeout=60)
 
     return response1 != response2
 

--- a/resources/QuickSearch.py
+++ b/resources/QuickSearch.py
@@ -85,6 +85,6 @@ class QuickSearch(Resource):
                 webhook_url,
                 data=json.dumps(message),
                 headers={"Content-Type": "application/json"},
-            )
+            timeout=60)
 
             return {"count": 0, "message": user_message}, 500

--- a/resources/RequestResetPassword.py
+++ b/resources/RequestResetPassword.py
@@ -52,7 +52,7 @@ class RequestResetPassword(Resource):
                     "subject": "PDAP Data Sources Reset Password",
                     "text": body,
                 },
-            )
+            timeout=60)
 
             return {
                 "message": "An email has been sent to your email address with a link to reset your password. It will be valid for 15 minutes.",

--- a/resources/SearchTokens.py
+++ b/resources/SearchTokens.py
@@ -96,7 +96,7 @@ class SearchTokens(Resource):
                         webhook_url,
                         data=json.dumps(message),
                         headers={"Content-Type": "application/json"},
-                    )
+                    timeout=60)
 
                     return {"count": 0, "message": user_message}, 500
 


### PR DESCRIPTION
Many developers will be surprised to learn that `requests` library calls do not include timeouts by default. This means that an attempted request could hang indefinitely if no connection is established or if no data is received from the server. 

The [requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) suggests that most calls should explicitly include a `timeout` parameter. This codemod adds a default timeout value in order to set an upper bound on connection times and ensure that requests connect or fail in a timely manner. This value also ensures the connection will timeout if the server does not respond with data within a reasonable amount of time. 

While timeout values will be application dependent, we believe that this codemod adds a reasonable default that serves as an appropriate ceiling for most situations. 

Our changes look like the following:
```diff
 import requests
 
- requests.get("http://example.com")
+ requests.get("http://example.com", timeout=60)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python-requests.org/en/master/user/quickstart/#timeouts](https://docs.python-requests.org/en/master/user/quickstart/#timeouts)
</details>


Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/add-requests-timeouts](https://docs.pixee.ai/codemods/python/pixee_python_add-requests-timeouts)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fdata-sources-app%7C582a6f4e067b14ec0843bec0aa27e2a6d244de2c)

<!--{"type":"DRIP","codemod":"pixee:python/add-requests-timeouts"}-->