### PR TITLE
Add search API functionality

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,8 @@
 from flask import Flask
-from flask_restful import Api
+from flask_restx import Api
 from flask_cors import CORS
+
+from resources.Search import Search
 from resources.User import User
 from resources.Login import Login
 from resources.RefreshSession import RefreshSession
@@ -41,6 +43,7 @@ def create_app() -> Flask:
         (ResetPassword, "/reset-password"),
         (ResetTokenValidation, "/reset-token-validation"),
         (QuickSearch, "/quick-search/<search>/<location>"),
+        (Search, "/search/<string:coarse_record_type>/<string:location>"),
         (Archives, "/archives"),
         (DataSources, "/data-sources"),
         (DataSourcesMap, "/data-sources-map"),

--- a/middleware/search_query.py
+++ b/middleware/search_query.py
@@ -1,0 +1,216 @@
+import spacy
+import json
+import datetime
+from utilities.common import convert_dates_to_strings, format_arrays
+from typing import List, Dict, Any, Optional
+from psycopg2.extensions import connection as PgConnection, cursor as PgCursor
+
+# TODO: Create search_query_logs table to complement quick_search_query_logs
+
+
+def expand_params(single_param, times):
+    """
+    Generates a tuple containing the same parameter repeated multiple times.
+
+    Simplifies the creation of tuples for SQL query parameters
+    where the same value needs to be used multiple times in a parameterized SQL query. This
+    function maintains readability and cleanliness by avoiding manual repetition
+    of parameters.
+    Parameters:
+    single_param (any): The parameter to be repeated in the tuple. This can be any data type that
+                        is compatible with the SQL query parameter requirements, such as strings,
+                        numbers, etc.
+    times (int): The number of times `single_param` should be repeated in the tuple.
+
+    Returns:
+    tuple: A tuple consisting of `single_param` repeated `times` times.
+
+    Example:
+    >>> expand_params('example', 3)
+    ('example', 'example', 'example')
+    """
+    return tuple([single_param] * times)
+
+
+QUICK_SEARCH_COLUMNS = [
+    "airtable_uid",
+    "data_source_name",
+    "description",
+    "record_type",
+    "source_url",
+    "record_format",
+    "coverage_start",
+    "coverage_end",
+    "agency_supplied",
+    "agency_name",
+    "municipality",
+    "state_iso",
+]
+
+QUICK_SEARCH_SQL = """
+    SELECT
+        data_sources.airtable_uid,
+        data_sources.name AS data_source_name,
+        data_sources.description,
+        data_sources.record_type,
+        data_sources.source_url,
+        data_sources.record_format,
+        data_sources.coverage_start,
+        data_sources.coverage_end,
+        data_sources.agency_supplied,
+        agencies.name AS agency_name,
+        agencies.municipality,
+        agencies.state_iso
+    FROM
+        agency_source_link
+    INNER JOIN
+        data_sources ON agency_source_link.airtable_uid = data_sources.airtable_uid
+    INNER JOIN
+        agencies ON agency_source_link.agency_described_linked_uid = agencies.airtable_uid
+    INNER JOIN
+        state_names ON agencies.state_iso = state_names.state_iso
+    WHERE
+        data_sources.record_type = ANY(%s)  AND 
+        (
+            agencies.county_name LIKE %s OR 
+            substr(agencies.county_name,3,length(agencies.county_name)-4) || ' County' LIKE %s 
+            OR agencies.state_iso LIKE %s 
+            OR agencies.municipality LIKE %s 
+            OR agencies.agency_type LIKE %s 
+            OR agencies.jurisdiction_type LIKE %s 
+            OR agencies.name LIKE %s 
+            OR state_names.state_name LIKE %s
+        )
+        AND data_sources.approval_status = 'approved'
+        AND data_sources.url_status not in ('broken', 'none found')
+
+"""
+
+INSERT_LOG_QUERY = """
+INSERT INTO search_query_logs 
+(search, location, results, result_count, created_at, datetime_of_request) 
+VALUES (%s, %s, %s, %s, %s, %s)
+"""
+
+
+class SearchQueryEngine:
+    """
+
+    This class represents a search query engine that can be used to perform
+    SQL queries for searching records based on a search term and location.
+    """
+
+    def __init__(self, connection: PgConnection):
+        self.conn = connection
+        self.nlp = spacy.load("en_core_web_sm")
+
+    def execute_query(
+        self, coarse_record_types: list[str], location: str
+    ) -> List[Dict[str, Any]]:
+        """
+        Execute a SQL query to search for records based on a search term and location.
+
+        :param search_term: The search term to query for.
+        :param location: The location to search within.
+        :return: A list of dictionaries containing the fetched records.
+        """
+        assert isinstance(
+            coarse_record_types, list
+        ), "coarse_record_types must be a list"
+        with self.conn.cursor() as cursor:
+            cursor.execute(
+                QUICK_SEARCH_SQL, (coarse_record_types,) + expand_params(location, 8)
+            )
+            return cursor.fetchall()
+
+    def print_query_parameters(self, search_terms: list[str], location: str) -> None:
+        """
+        :param search_terms: The search term used in the query. It should be of type str.
+        :param location: The location used in the query. It should be of type str.
+        :return: None.
+        """
+        print(f"Query parameters: '%{search_terms}%', '%{location}%'")
+
+    def process_search_term(
+        self, coarse_record_types: list[str], lemmatize: bool = False
+    ) -> list[str]:
+        """
+
+        :param coarse_record_types: the coarse record types to be processed
+        :param lemmatize: A boolean indicating whether the search term should be depluralized (lemmatized).
+        :return: The processed search term.
+
+        """
+        search_terms = []
+        if lemmatize:
+            for coarse_record_type in coarse_record_types:
+                doc = self.nlp(coarse_record_type.strip())
+                search_term = " ".join([token.lemma_ for token in doc])
+                search_terms.append(search_term)
+        return search_terms
+
+    def search_query(
+        self, coarse_record_type: list[str], location: str, lemmatize: bool = False
+    ) -> List[Dict[str, Any]]:
+        """
+        Perform a search query based on the given parameters.
+
+        :param coarse_record_type: A string representing the coarse record type to search for.
+        :param location: A string representing the location to search within.
+        :param lemmatize: A boolean indicating whether or not to depluralize (lemmatize) the search term. Defaults to False.
+
+        :return: A list of dictionaries, where each dictionary represents a search result.
+
+        """
+        search_term = self.process_search_term(coarse_record_type, lemmatize)
+        self.print_query_parameters(search_term, location)
+        results = self.execute_query(search_term, location)
+        return results
+
+    def quick_search(
+        self,
+        coarse_record_type: list[str] = None,
+        location: str = "",
+        test: bool = False,
+    ) -> Dict[str, Any]:
+        """
+        Perform a quick search based on the provided parameters.
+
+        :param coarse_record_type: The type of record to search for.
+        :param location: The location to search for records in.
+        :param test: A flag indicating whether this is a test search.
+        :return: A dictionary containing the search results.
+        """
+        unaltered_results = self.search_query(
+            coarse_record_type, location, lemmatize=False
+        )
+        spacy_results = self.search_query(coarse_record_type, location, lemmatize=True)
+
+        results = (
+            spacy_results
+            if len(spacy_results) > len(unaltered_results)
+            else unaltered_results
+        )
+        data_sources = {"count": len(results), "data": results}
+
+        if not test:
+            self.log_query_results(coarse_record_type, location, data_sources)
+
+        return data_sources
+
+    def log_query_results(
+        self, coarse_record_type: str, location: str, data_sources: Dict[str, Any]
+    ) -> None:
+        datetime_string = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        query_results = json.dumps(data_sources["data"]).replace("'", "")
+        with self.conn.cursor() as cursor:
+            cursor.execute(
+                INSERT_LOG_QUERY.format(
+                    coarse_record_type,
+                    location,
+                    query_results,
+                    data_sources["count"],
+                    datetime_string,
+                ),
+            )
+            self.conn.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ exceptiongroup==1.1.3
 Flask==2.3.2
 Flask-Cors==4.0.0
 Flask-RESTful==0.3.10
+flask-restx==1.3.0
 gotrue==1.0.3
 gunicorn==21.2.0
 h11==0.14.0

--- a/resources/PsycopgResource.py
+++ b/resources/PsycopgResource.py
@@ -1,12 +1,13 @@
-from flask_restful import Resource
+from flask_restx import Resource
 
 
 class PsycopgResource(Resource):
-    def __init__(self, **kwargs):
+    def __init__(self, *args, **kwargs):
         """
         Initializes the resource with a database connection.
         - kwargs (dict): Keyword arguments containing 'psycopg2_connection' for database connection.
         """
+        super().__init__(*args, **kwargs)
         self.psycopg2_connection = kwargs["psycopg2_connection"]
 
     def get(self):

--- a/resources/Search.py
+++ b/resources/Search.py
@@ -15,11 +15,10 @@ class Search(PsycopgResource):
     Provides a resource for performing quick searches in the database for data sources
     based on user-provided search terms and location.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.engine = SearchQueryEngine(
-            connection=self.psycopg2_connection
-        )
+        self.engine = SearchQueryEngine(connection=self.psycopg2_connection)
 
     # api_required decorator requires the request"s header to include an "Authorization" key with the value formatted as "Bearer [api_key]"
     # A user can get an API key by signing up and logging in (see User.py)
@@ -46,15 +45,11 @@ class Search(PsycopgResource):
         if isinstance(coarse_record_types, str):
             course_record_types = [coarse_record_types]
         try:
-            data_sources = self.engine.quick_search(
-                course_record_types, location, test
-            )
+            data_sources = self.engine.quick_search(course_record_types, location, test)
 
             if data_sources["count"] == 0:
                 self.psycopg2_connection = initialize_psycopg2_connection()
-                data_sources = self.engine.quick_search(
-                    course_record_types, location
-                )
+                data_sources = self.engine.quick_search(course_record_types, location)
 
             if data_sources["count"] == 0:
                 return {
@@ -74,11 +69,11 @@ class Search(PsycopgResource):
             user_message = "There was an error during the search operation"
             message = {
                 "content": user_message
-                           + ": "
-                           + str(e)
-                           + "\n"
-                           + f"Record Types: {course_record_types}\n"
-                           + f"Location: {location}"
+                + ": "
+                + str(e)
+                + "\n"
+                + f"Record Types: {course_record_types}\n"
+                + f"Location: {location}"
             }
             requests.post(
                 webhook_url,

--- a/resources/Search.py
+++ b/resources/Search.py
@@ -1,0 +1,89 @@
+from middleware.search_query import SearchQueryEngine
+from middleware.security import api_required
+import requests
+import json
+import os
+from middleware.initialize_psycopg2_connection import initialize_psycopg2_connection
+from flask import request
+from typing import Dict, Any
+
+from resources.PsycopgResource import PsycopgResource
+
+
+class Search(PsycopgResource):
+    """
+    Provides a resource for performing quick searches in the database for data sources
+    based on user-provided search terms and location.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.engine = SearchQueryEngine(
+            connection=self.psycopg2_connection
+        )
+
+    # api_required decorator requires the request"s header to include an "Authorization" key with the value formatted as "Bearer [api_key]"
+    # A user can get an API key by signing up and logging in (see User.py)
+    @api_required
+    def get(self, coarse_record_types: str, location: str) -> Dict[str, Any]:
+        """
+        Performs a quick search using the provided search terms and location. It attempts to find relevant
+        data sources in the database. If no results are found initially, it re-initializes the database
+        connection and tries again.
+
+        Parameters:
+        - search (str): The search term provided by the user.
+        - location (str): The location provided by the user.
+
+        Returns:
+        - A dictionary containing a message about the search results and the data found, if any.
+        """
+        try:
+            data = request.get_json()
+            test = data.get("test_flag")
+        except:
+            test = False
+
+        if isinstance(coarse_record_types, str):
+            course_record_types = [coarse_record_types]
+        try:
+            data_sources = self.engine.quick_search(
+                course_record_types, location, test
+            )
+
+            if data_sources["count"] == 0:
+                self.psycopg2_connection = initialize_psycopg2_connection()
+                data_sources = self.engine.quick_search(
+                    course_record_types, location
+                )
+
+            if data_sources["count"] == 0:
+                return {
+                    "count": 0,
+                    "message": "No results found. Please considering requesting a new data source.",
+                }, 404
+
+            return {
+                "message": "Results for search successfully retrieved",
+                "data": data_sources,
+            }
+
+        except Exception as e:
+            self.psycopg2_connection.rollback()
+            print(str(e))
+            webhook_url = os.getenv("WEBHOOK_URL")
+            user_message = "There was an error during the search operation"
+            message = {
+                "content": user_message
+                           + ": "
+                           + str(e)
+                           + "\n"
+                           + f"Record Types: {course_record_types}\n"
+                           + f"Location: {location}"
+            }
+            requests.post(
+                webhook_url,
+                data=json.dumps(message),
+                headers={"Content-Type": "application/json"},
+            )
+
+            return {"count": 0, "message": user_message}, 500


### PR DESCRIPTION
#### Fixes

* Partially addresses #249

#### Description

* Incorporate search api per specifications for #249
* Additionally replaces flask_restful with flask_restx invocation. 

#### Testing

* TODO:

#### Performance

* Performance impact expected to be limited -- Largest impact is likely to depend on how many search results are returned.

#### Docs

* Incorporating Flask_restx enables documentation to be automatically generated from docstrings in `Resource`. 
* To view documentation -- start `app.py` and navigate to server location. Then click on "Default namespace" to view the full docuemtnation for all methods.
* Namespace can be eventually configured, but is beyond the scope of this PR.  