### PR TITLE
Create workflow for copying Production Database to Dev Database

### DIFF
--- a/.github/scripts/dump_prod_to_dev.sh
+++ b/.github/scripts/dump_prod_to_dev.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Define the path for the dump file
+DUMP_FILE="prod_dump.sql"
+
+echo "Dumping production database..."
+pg_dump $PROD_DB_CONN_STRING > $DUMP_FILE
+
+echo "Dropping all connections to the development database..."
+psql -d $DEV_ADMIN_DB_CONN_STRING -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = 'dev_dbname' AND pid <> pg_backend_pid();"
+
+echo "Dropping the development database..."
+psql -d $DEV_ADMIN_DB_CONN_STRING -c "DROP DATABASE IF EXISTS pdap_dev_db;"
+
+echo "Creating development database..."
+psql -d $DEV_ADMIN_DB_CONN_STRING -c "CREATE DATABASE pdap_dev_db;"
+
+echo "Restoring dump to development database..."
+psql $DEV_DB_CONN_STRING < $DUMP_FILE

--- a/.github/workflows/dump_prod_to_dev.yml
+++ b/.github/workflows/dump_prod_to_dev.yml
@@ -1,3 +1,15 @@
+# This script will sync the production database environment
+# to the dev database environment on a weekly basis
+# It requires the following Github Secrets:
+# PROD_DB_CONN_STRING: A connection string to the prod database
+#   for user "prod_dump_agent"
+# DEV_ADMIN_DB_CONN_STRING: A connection string to the development database
+#   at database "defaultdb" for user "doadmin"
+#   must be a separate string from DEV_DB_CONN_STRING
+#   to enable closing and rebuilding the "pdab_dev_db" database.
+# DEV_DB_CONN_STRING: A connection string to the development database
+##   at database "pdap_dev_db" for user "doadmin"
+
 name: Sync Production to Development
 
 on:

--- a/.github/workflows/dump_prod_to_dev.yml
+++ b/.github/workflows/dump_prod_to_dev.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Runs at 00:00 every Monday
     - cron: '0 0 * * 1'
+  workflow_dispatch:
 
 jobs:
   sync-database:

--- a/.github/workflows/dump_prod_to_dev.yml
+++ b/.github/workflows/dump_prod_to_dev.yml
@@ -1,0 +1,22 @@
+name: Sync Production to Development
+
+on:
+  schedule:
+    # Runs at 00:00 every Monday
+    - cron: '0 0 * * 1'
+
+jobs:
+  sync-database:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run shell script to dump and restore database
+        run: |
+          chmod +x ./github/scripts/dump_prod_to_dev.sh
+          ./github/scripts/dump_prod_to_dev.sh
+        env:
+          PROD_DB_CONN_STRING: ${{ secrets.PROD_DB_CONN_STRING }}
+          DEV_ADMIN_DB_CONN_STRING: ${{ secrets.DEV_ADMIN_DB_CONN_STRING }}
+          DEV_DB_CONN_STRING: ${{ secrets.DEV_DB_CONN_STRING }}


### PR DESCRIPTION
#### Fixes

* Partially addresses #271

#### Description

* This creates a workflow designed to copy the production database into the dev database

#### Testing

* Should be able to test performance by running a manual dispatch of the Github Action
* Note that the Github Secrets described within the Github Action will need to be provided -- I can provide the associated connection strings on request.

#### Performance

* Running on my personal machine, dump from the database and pushing to production took around 6 minutes. 
* Unclear how that will translate to a Github Action Runner.

#### Docs

* TODO: Unclear if applicable.