### PR TITLE
Fix quick_search_query logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# data-sources-app
+# data-sources-app-v2
+
+Development of the next big iteration of the data sources app according to https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/248
 
 An API and UI for searching, using, and maintaining Data Sources. 
 


### PR DESCRIPTION
#### Fixes

* Partially fixes https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/270 - "modify quick search logs -- store the airtable_uid of data sources as results, not a full package

#### Description

* Replaces prior logging logic of quick_search_query logging with new method which inserts a list of the airtable_uids of results, rather than the whole package of results.
* Additionally, this modifies the INSERT_LOG_QUERY to be paramaterized, rather than involve string insertion, reducing risk of sql injection

#### Testing

* TODO

#### Performance

* Marginal performance impact -- adding all ids of the results is an O(n) action, with n being the number of results.  

#### Docs

* No docs required