### PR TITLE
shuffle results messaging

### DIFF
--- a/client/src/pages/SearchResultPage.vue
+++ b/client/src/pages/SearchResultPage.vue
@@ -31,13 +31,13 @@
 		</p>
 
 		<p class="text-xl max-w-full">
-				If you don't see what you need,
-				<a
-					href="https://airtable.com/shrbFfWk6fjzGnNsk"
-					data-test="search-results-request-link"
-				>
-					make a request&nbsp;<i class="fa fa-external-link" />
-				</a>
+			If you don't see what you need,
+			<a
+				href="https://airtable.com/shrbFfWk6fjzGnNsk"
+				data-test="search-results-request-link"
+			>
+				make a request&nbsp;<i class="fa fa-external-link" />
+			</a>
 		</p>
 
 		<div data-test="search-results">

--- a/client/src/pages/SearchResultPage.vue
+++ b/client/src/pages/SearchResultPage.vue
@@ -24,7 +24,7 @@
 		</p>
 
 		<p v-else class="text-xl max-w-full">
-			If you'd prefer to use a spreadsheet,
+			To see this data in table form,
 			<a href="https://airtable.com/shrUAtA8qYasEaepI">
 				view the full database&nbsp;<i class="fa fa-external-link" />
 			</a>

--- a/client/src/pages/SearchResultPage.vue
+++ b/client/src/pages/SearchResultPage.vue
@@ -23,8 +23,14 @@
 			No results found.
 		</p>
 
-		<div v-else>
-			<p class="text-xl max-w-full">
+		<p v-else class="text-xl max-w-full">
+			If you'd prefer to use a spreadsheet,
+			<a href="https://airtable.com/shrUAtA8qYasEaepI">
+				view the full database&nbsp;<i class="fa fa-external-link" />
+			</a>
+		</p>
+
+		<p class="text-xl max-w-full">
 				If you don't see what you need,
 				<a
 					href="https://airtable.com/shrbFfWk6fjzGnNsk"
@@ -32,14 +38,7 @@
 				>
 					make a request&nbsp;<i class="fa fa-external-link" />
 				</a>
-			</p>
-			<p class="text-xl max-w-full">
-				To see these results in a table,
-				<a href="https://airtable.com/shrUAtA8qYasEaepI">
-					view the full database&nbsp;<i class="fa fa-external-link" />
-				</a>
-			</p>
-		</div>
+		</p>
 
 		<div data-test="search-results">
 			<section

--- a/client/src/pages/__tests__/__snapshots__/searchResultPage.test.js.snap
+++ b/client/src/pages/__tests__/__snapshots__/searchResultPage.test.js.snap
@@ -10,14 +10,12 @@ exports[`SearchResultPage renders with data > Calls API and renders search resul
       <i class="fa fa-plus"></i> New search
     </button>
   </div>
-  <div>
-    <p class="text-xl max-w-full"> If you don't see what you need, <a href="https://airtable.com/shrbFfWk6fjzGnNsk"> make a request <i class="fa fa-external-link"></i>
-      </a>
-    </p>
-    <p class="text-xl max-w-full"> To see these results in a table, <a href="https://airtable.com/shrUAtA8qYasEaepI"> view the full database <i class="fa fa-external-link"></i>
-      </a>
-    </p>
-  </div>
+  <p class="text-xl max-w-full"> To see this data in table form, <a href="https://airtable.com/shrUAtA8qYasEaepI"> view the full database <i class="fa fa-external-link"></i>
+    </a>
+  </p>
+  <p class="text-xl max-w-full"> If you don't see what you need, <a href="https://airtable.com/shrbFfWk6fjzGnNsk"> make a request <i class="fa fa-external-link"></i>
+    </a>
+  </p>
   <div>
     <section class="mt-8 p-0 w-full">
       <h2 class="section-subheading w-full">Police & public interactions</h2>

--- a/client/src/pages/__tests__/__snapshots__/searchResultPage.test.js.snap
+++ b/client/src/pages/__tests__/__snapshots__/searchResultPage.test.js.snap
@@ -10,14 +10,12 @@ exports[`SearchResultPage renders with data > Calls API and renders search resul
       <i class="fa fa-plus"></i> New search
     </button>
   </div>
-  <div>
-    <p class="text-xl max-w-full"> To see these results in table form, <a href="https://airtable.com/shrUAtA8qYasEaepI"> view the full database <i class="fa fa-external-link"></i>
-      </a>
-    </p>
-    <p class="text-xl max-w-full"> If you don't see what you need, <a href="https://airtable.com/shrbFfWk6fjzGnNsk"> make a request <i class="fa fa-external-link"></i>
-      </a>
-    </p>
-  </div>
+  <p class="text-xl max-w-full"> To see these results in table form, <a href="https://airtable.com/shrUAtA8qYasEaepI"> view the full database <i class="fa fa-external-link"></i>
+    </a>
+  </p>
+  <p class="text-xl max-w-full"> If you don't see what you need, <a href="https://airtable.com/shrbFfWk6fjzGnNsk"> make a request <i class="fa fa-external-link"></i>
+    </a>
+  </p>
   <div>
     <section class="mt-8 p-0 w-full">
       <h2 class="section-subheading w-full">Police & public interactions</h2>

--- a/client/src/pages/__tests__/__snapshots__/searchResultPage.test.js.snap
+++ b/client/src/pages/__tests__/__snapshots__/searchResultPage.test.js.snap
@@ -10,12 +10,14 @@ exports[`SearchResultPage renders with data > Calls API and renders search resul
       <i class="fa fa-plus"></i> New search
     </button>
   </div>
-  <p class="text-xl max-w-full"> To see these results in table form, <a href="https://airtable.com/shrUAtA8qYasEaepI"> view the full database <i class="fa fa-external-link"></i>
-    </a>
-  </p>
-  <p class="text-xl max-w-full"> If you don't see what you need, <a href="https://airtable.com/shrbFfWk6fjzGnNsk"> make a request <i class="fa fa-external-link"></i>
-    </a>
-  </p>
+  <div>
+    <p class="text-xl max-w-full"> To see these results in table form, <a href="https://airtable.com/shrUAtA8qYasEaepI"> view the full database <i class="fa fa-external-link"></i>
+      </a>
+    </p>
+    <p class="text-xl max-w-full"> If you don't see what you need, <a href="https://airtable.com/shrbFfWk6fjzGnNsk"> make a request <i class="fa fa-external-link"></i>
+      </a>
+    </p>
+  </div>
   <div>
     <section class="mt-8 p-0 w-full">
       <h2 class="section-subheading w-full">Police & public interactions</h2>

--- a/client/src/pages/__tests__/__snapshots__/searchResultPage.test.js.snap
+++ b/client/src/pages/__tests__/__snapshots__/searchResultPage.test.js.snap
@@ -11,10 +11,10 @@ exports[`SearchResultPage renders with data > Calls API and renders search resul
     </button>
   </div>
   <div>
-    <p class="text-xl max-w-full"> To see these results in table form, <a href="https://airtable.com/shrUAtA8qYasEaepI"> view the full database <i class="fa fa-external-link"></i>
+    <p class="text-xl max-w-full"> If you don't see what you need, <a href="https://airtable.com/shrbFfWk6fjzGnNsk"> make a request <i class="fa fa-external-link"></i>
       </a>
     </p>
-    <p class="text-xl max-w-full"> If you don't see what you need, <a href="https://airtable.com/shrbFfWk6fjzGnNsk"> make a request <i class="fa fa-external-link"></i>
+    <p class="text-xl max-w-full"> To see these results in a table, <a href="https://airtable.com/shrUAtA8qYasEaepI"> view the full database <i class="fa fa-external-link"></i>
       </a>
     </p>
   </div>

--- a/client/src/pages/__tests__/__snapshots__/searchResultPage.test.js.snap
+++ b/client/src/pages/__tests__/__snapshots__/searchResultPage.test.js.snap
@@ -11,10 +11,10 @@ exports[`SearchResultPage renders with data > Calls API and renders search resul
     </button>
   </div>
   <div>
-    <p class="text-xl max-w-full"> If you don't see what you need, <a href="https://airtable.com/shrbFfWk6fjzGnNsk"> make a request <i class="fa fa-external-link"></i>
+    <p class="text-xl max-w-full"> To see these results in table form, <a href="https://airtable.com/shrUAtA8qYasEaepI"> view the full database <i class="fa fa-external-link"></i>
       </a>
     </p>
-    <p class="text-xl max-w-full"> To see these results in a table, <a href="https://airtable.com/shrUAtA8qYasEaepI"> view the full database <i class="fa fa-external-link"></i>
+    <p class="text-xl max-w-full"> If you don't see what you need, <a href="https://airtable.com/shrbFfWk6fjzGnNsk"> make a request <i class="fa fa-external-link"></i>
       </a>
     </p>
   </div>


### PR DESCRIPTION
fixes #294 

now, this note about making a request will always show, regardless how many results appear. before, it wasn't showing when there were 0 results.

<img width="650" alt="Screen Shot 2024-05-30 at 3 46 21 PM" src="https://github.com/Police-Data-Accessibility-Project/data-sources-app/assets/30379833/45729aa1-d3f6-4580-945e-f484089a905a">
