### PR TITLE
⚡️ feat(middleware): Add functionality to cache homepage search results

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,8 @@
 from flask import Flask
 from flask_restful import Api
 from flask_cors import CORS
+
+from resources.HomepageSearchCache import HomepageSearchCache
 from resources.User import User
 from resources.Login import Login
 from resources.RefreshSession import RefreshSession
@@ -48,6 +50,7 @@ def create_app() -> Flask:
         (DataSourceById, "/data-sources-by-id/<data_source_id>"),
         (Agencies, "/agencies/<page>"),
         (SearchTokens, "/search-tokens"),
+        (HomepageSearchCache, "/homepage-search-cache"),
     ]
 
     for resource, endpoint in resources:

--- a/middleware/homepage_search_cache.py
+++ b/middleware/homepage_search_cache.py
@@ -1,0 +1,50 @@
+import psycopg2
+from flask import Response, make_response
+
+SQL_GET_AGENCIES_WITHOUT_HOMEPAGE_URLS = """
+    SELECT
+        SUBMITTED_NAME,
+        JURISDICTION_TYPE,
+        STATE_ISO,
+        MUNICIPALITY,
+        COUNTY_NAME,
+        AIRTABLE_UID,
+        COUNT_DATA_SOURCES,
+        ZIP_CODE,
+        NO_WEB_PRESENCE -- Relevant
+    FROM
+        PUBLIC.AGENCIES
+    WHERE 
+        approved = true
+        AND homepage_url is null
+        AND NOT EXISTS (
+            SELECT 1 FROM PUBLIC.AGENCY_URL_SEARCH_CACHE
+            WHERE PUBLIC.AGENCIES.AIRTABLE_UID = PUBLIC.AGENCY_URL_SEARCH_CACHE.agency_airtable_uid
+        )
+    ORDER BY COUNT_DATA_SOURCES DESC
+    LIMIT 100 -- Limiting to 100 in acknowledgment of the search engine quota
+"""
+
+SQL_UPDATE_CACHE = """
+    INSERT INTO public.agency_url_search_cache
+    (agency_airtable_uid, search_result)
+    VALUES (%s, %s)
+"""
+
+
+def get_agencies_without_homepage_urls(cursor: psycopg2.extensions.cursor) -> Response:
+    cursor.execute(SQL_GET_AGENCIES_WITHOUT_HOMEPAGE_URLS)
+    results = cursor.fetchall()
+    output = []
+    for result in results:
+        dict_result = dict(zip([i[0] for i in cursor.description], result))
+        output.append(dict_result)
+    return make_response(output, 200)
+
+
+def update_search_cache(
+    cursor: psycopg2.extensions.cursor, agency_uid: str, search_results: list[str]
+) -> Response:
+    for result in search_results:
+        cursor.execute(SQL_UPDATE_CACHE, (agency_uid, result))
+    return make_response("Search Cache Updated", 200)

--- a/resources/HomepageSearchCache.py
+++ b/resources/HomepageSearchCache.py
@@ -1,0 +1,33 @@
+from flask import request
+
+from middleware.homepage_search_cache import (
+    get_agencies_without_homepage_urls,
+    update_search_cache,
+)
+from middleware.security import api_required
+from resources.PsycopgResource import PsycopgResource
+
+
+class HomepageSearchCache(PsycopgResource):
+
+    @api_required
+    def get(self):
+        """
+        Retrieve 100 agencies without homepage urls
+        :return:
+        """
+        with self.psycopg2_connection.cursor() as cursor:
+            return get_agencies_without_homepage_urls(cursor)
+
+    @api_required
+    def post(self):
+        """
+        Update search cache
+        :return:
+        """
+        with self.psycopg2_connection.cursor() as cursor:
+            return update_search_cache(
+                cursor=cursor,
+                agency_uid=request.json["agency_uid"],
+                search_results=request.json["search_results"],
+            )


### PR DESCRIPTION

#### Fixes

* Partially addresses https://github.com/Police-Data-Accessibility-Project/data-source-identification/issues/53

#### Description

- Added new middleware file `homepage_search_cache.py` to handle caching of search results for agencies without homepage URLs
- Added SQL queries to retrieve agencies without homepage URLs and update the search cache
- Implemented functions to get agencies without homepage URLs and update search cache
- Added new resource `HomepageSearchCache` in `resources/HomepageSearchCache.py` to handle API requests for retrieving and updating search cache

#### Testing

* Not sure! I could set up an integration test for it, or we could deploy it and see if it works/doesn't break things when I reconfigure the data source identification code to work with it, or try some unknown third option.

#### Performance

* Creation of new endpoint. As untested, performance impact unknown, but likely minimal. 

#### Docs

* https://app.gitbook.com/o/-MXypK5ySzExtEzQU6se/s/-MXyolqTg_voOhFyAcr-/~/changes/498/api/v2-api-docs-wip