### PR TITLE
Malformed url bug fix

### DIFF
--- a/client/src/components/SearchResultCard.vue
+++ b/client/src/components/SearchResultCard.vue
@@ -149,7 +149,11 @@ export default {
 			this.$router.push(`/data-sources/${this.dataSource.airtable_uid}`);
 		},
 		openSource() {
-			window.open(this.dataSource.source_url, '_blank');
+			let url = this.dataSource.source_url;
+			if (!/^https?:\/\//i.test(url)) {
+				url = 'https://' + url;
+			}
+			window.open(url, '_blank');
 		},
 		formatDate: formatDateForSearchResults,
 	},

--- a/client/src/components/SearchResultCard.vue
+++ b/client/src/components/SearchResultCard.vue
@@ -149,13 +149,13 @@ export default {
 			this.$router.push(`/data-sources/${this.dataSource.airtable_uid}`);
 		},
 		openSource() {
-			let url = this.dataSource.source_url;
-            // ensure URL is treated as an absolute path
-            url = this.prepend_protocol_if_none(url)
+	        let url = this.dataSource.source_url;
+			// ensure URL is treated as an absolute path
+			url = this.prepend_protocol_if_none(url)
 			window.open(url, '_blank');
 		},
-		prepend_protocol_if_none(url) {
-		    // add 'https://' if the URL does not have a protocol
+                prepend_protocol_if_none(url) {
+			// add 'https://' if the URL does not have a protocol
 			if (!/^https?:\/\//i.test(url)) {
 				return url = 'https://' + url;
 			}

--- a/client/src/components/SearchResultCard.vue
+++ b/client/src/components/SearchResultCard.vue
@@ -149,7 +149,7 @@ export default {
 			this.$router.push(`/data-sources/${this.dataSource.airtable_uid}`);
 		},
 		openSource() {
-	        let url = this.dataSource.source_url;
+	        	let url = this.dataSource.source_url;
 			// ensure URL is treated as an absolute path
 			url = this.prepend_protocol_if_none(url)
 			window.open(url, '_blank');

--- a/client/src/components/SearchResultCard.vue
+++ b/client/src/components/SearchResultCard.vue
@@ -150,10 +150,16 @@ export default {
 		},
 		openSource() {
 			let url = this.dataSource.source_url;
-			if (!/^https?:\/\//i.test(url)) {
-				url = 'https://' + url;
-			}
+            // ensure URL is treated as an absolute path
+            url = this.prepend_protocol_if_none(url)
 			window.open(url, '_blank');
+		},
+		prepend_protocol_if_none(url) {
+		    // add 'https://' if the URL does not have a protocol
+			if (!/^https?:\/\//i.test(url)) {
+				return url = 'https://' + url;
+			}
+			return url;
 		},
 		formatDate: formatDateForSearchResults,
 	},

--- a/middleware/initialize_psycopg2_connection.py
+++ b/middleware/initialize_psycopg2_connection.py
@@ -2,6 +2,7 @@ import psycopg2
 import os
 from psycopg2.extensions import connection as PgConnection
 from typing import Union, Dict, List
+from dotenv import load_dotenv
 
 
 def initialize_psycopg2_connection() -> (
@@ -17,6 +18,7 @@ def initialize_psycopg2_connection() -> (
     :return: A psycopg2 connection object if successful, or a dictionary with a count of 0 and an empty data list upon failure.
     """
     try:
+        load_dotenv()
         DO_DATABASE_URL = os.getenv("DO_DATABASE_URL")
 
         return psycopg2.connect(


### PR DESCRIPTION
Fixes #338

`client/src/components/SearchResultCard.vue`
- javascript window.open() method assumes that without http(s):// it's a relative path. So this checks source_url and prepends https:// if not found.

`middleware/initialize_psycopg2_connection.py`
- explicitly load .env variables with dotenv