### PR TITLE
Fix quick search not showing all results - v1 patch

### DIFF
--- a/client/src/util/pageData.js
+++ b/client/src/util/pageData.js
@@ -169,6 +169,7 @@ export const SEARCH_RESULTS_UI_SHAPE = [
 		records: [
 			{ type: 'Crime Maps & Reports' },
 			{ type: 'Crime Statistics' },
+			{ type: 'Media Bulletins'},
 			{ type: 'Records Request Info' },
 			{ type: 'Resources' },
 			{ type: 'Sex Offender Registry' },
@@ -182,5 +183,11 @@ export const SEARCH_RESULTS_UI_SHAPE = [
 			{ type: 'Court Cases' },
 			{ type: 'Incarceration Records' },
 		],
+	},
+	{
+		header: 'Other',
+		records: [
+			{ type: 'Other' },
+		]
 	},
 ];


### PR DESCRIPTION
#### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/348

#### Description

* Added two missing categories to `pageData.js`: `Media Bulletins` and `Other`
* A new header `Other` is used for `Other` record types, `Media Bulletins` is grouped under `Agency-published resources`

![image](https://github.com/Police-Data-Accessibility-Project/data-sources-app-v2/assets/84819232/78b1a58c-6192-4384-b47b-68f43d6d7185)
![image](https://github.com/Police-Data-Accessibility-Project/data-sources-app-v2/assets/84819232/4da5c64f-a155-4f30-ae1e-a3a48501c191)

#### Testing

* Checkout the branch and setup testing environment like normal
* Search for and confirm previously unshown data sources are now shown on the results page