### PR TITLE
Add templates

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,0 +1,21 @@
+# Issue template
+
+### Context
+
+Brief description. Is this part of a parent issue?
+
+### Requirements
+
+* Required functionality.
+
+### Tests
+
+* Anything we should test for? How should it be tested?
+
+### Docs
+
+* What docs should be updated? Link to related docs changes in the PR.
+
+### Open questions
+
+* Any uncertainties? Anything we're flexible about?

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,26 @@
+# Pull request template
+
+#### Fixes
+
+* Issues being closed by this PR
+
+#### Description
+
+* A brief description of what this does. Include screenshots, if anything should change visually.
+
+#### Testing
+
+* Steps to test this PR, if there are any required.
+* For cut-and-dry changes (API updates or interface tweaks), include a screenshot or updated API response to show what correct behavior looks like
+
+#### Performance
+
+* If you're adding or heavily modifying a script, estimate how long it should take to run.
+
+#### Docs
+
+* Accompanying docs PRs, if applicable
+
+#### Breaking Changes
+
+* What functionality, if any, might be broken by this change, which could impact other developers. For example, an environmental variable changing.


### PR DESCRIPTION
fixes #402 

merging to main because it shouldn't affect anything downstream

looks like technically I did it the legacy way, but it should still work: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates