### PR TITLE
Mc 361 streamline archives put data retrieval

### DIFF
--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -20,7 +20,7 @@ jobs:
           - 5432:5432
 
     env:
-      FLASK_APP_COOKIE_ENCRYPTION_KEY: ${{ secrets.SECRET_KEY }}
+      FLASK_APP_COOKIE_ENCRYPTION_KEY: "cookieEncryptionKey"
       DO_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
       GH_CLIENT_ID: ${{secrets.GH_CLIENT_ID}}
       GH_CLIENT_SECRET: ${{secrets.GH_CLIENT_SECRET}}

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -22,8 +22,8 @@ jobs:
     env:
       FLASK_APP_COOKIE_ENCRYPTION_KEY: "cookieEncryptionKey"
       DO_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
-      GH_CLIENT_ID: ${{secrets.GH_CLIENT_ID}}
-      GH_CLIENT_SECRET: ${{secrets.GH_CLIENT_SECRET}}
+      GH_CLIENT_ID: "GithubProvidedClientId"
+      GH_CLIENT_SECRET: "GithubProvidedClientSecret"
       JWT_SECRET_KEY: "TestSecretKey"
       RESET_PASSWORD_SECRET_KEY: "resetTokenSecretKey"
       VALIDATE_EMAIL_SECRET_KEY: "validateEmailSecretKey"

--- a/resources/Archives.py
+++ b/resources/Archives.py
@@ -68,9 +68,6 @@ class Archives(PsycopgResource):
         ),
         description="""
         Updates the archive data based on the provided JSON payload.
-        Note that, for this endpoint only, the schema must be provided first as a json string,
-        rather than as a typical JSON object.
-        This will be changed in a later update to conform to the standard JSON schema.
         """,
     )
     @limiter.limit("25/minute;1000/hour")
@@ -86,12 +83,11 @@ class Archives(PsycopgResource):
             -   dict: A status message indicating success or an error message if an exception occurs.
         """
         json_data = request.get_json()
-        data = json.loads(json_data)
-        id = data["id"] if "id" in data else None
-        last_cached = data["last_cached"] if "last_cached" in data else None
+        id = json_data["id"] if "id" in json_data else None
+        last_cached = json_data["last_cached"] if "last_cached" in json_data else None
         broken_as_of = (
-            data["broken_source_url_as_of"]
-            if "broken_source_url_as_of" in data
+            json_data["broken_source_url_as_of"]
+            if "broken_source_url_as_of" in json_data
             else None
         )
         return self.run_endpoint(

--- a/tests/integration/test_archives.py
+++ b/tests/integration/test_archives.py
@@ -66,12 +66,10 @@ def test_archives_put(
         http_method="put",
         endpoint=ENDPOINT,
         headers=test_user_admin.jwt_authorization_header,
-        json=json.dumps(
-            {
+        json={
                 "id": data_source_id,
                 "last_cached": str(last_cached),
             }
-        ),
     )
 
     row = tdc.db_client.execute_raw_sql(

--- a/tests/integration/test_archives.py
+++ b/tests/integration/test_archives.py
@@ -67,9 +67,9 @@ def test_archives_put(
         endpoint=ENDPOINT,
         headers=test_user_admin.jwt_authorization_header,
         json={
-                "id": data_source_id,
-                "last_cached": str(last_cached),
-            }
+            "id": data_source_id,
+            "last_cached": str(last_cached),
+        },
     )
 
     row = tdc.db_client.execute_raw_sql(


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/361

### Description

* `/archives` `PUT` request previously required the body to be loaded as a json string, rather than just as json. This has been fixed.

### Testing

* Run tests and confirm functionality

### Performance

* Impact marginal

### Docs

* API documentation for `/archives` `PUT` modified to remove warning to use json string

### Breaking Changes

* This does technically break `/archives` `PUT`.
  * However, nothing but the archives repository (which is currently broken) uses this, and the prior method was not the correct way of doing it in the first place. 