### PR TITLE
fix(api): adjust `/archives` `GET` last_archived_before to accept `YYYY-MM-DD` format

### DIFF
--- a/middleware/schema_and_dto_logic/primary_resource_schemas/archives_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/archives_schemas.py
@@ -29,6 +29,7 @@ class ArchivesGetRequestSchema(Schema):
             "source": SourceMappingEnum.QUERY_ARGS,
             "description": "The date before which the url was archived (non-inclusive). Example: 2020-07-10",
         },
+        format="%Y-%m-%d",
     )
 
 

--- a/tests/helper_scripts/helper_classes/RequestValidator.py
+++ b/tests/helper_scripts/helper_classes/RequestValidator.py
@@ -318,7 +318,7 @@ class RequestValidator:
     ):
         endpoint_base = "/archives"
         if last_archived_before is not None:
-            last_archived_before = last_archived_before.isoformat()
+            last_archived_before = last_archived_before.strftime("%Y-%m-%d")
 
         params = {}
         d = {


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/649

### Description

* adjust /archives GET last_archived_before query parameter to accept YYYY-MM-DD format

### Testing

* Run tests and confirm functionality

### Performance

* Impact marginal 

### Docs

* No documentation change

### Breaking Changes

* This does technically break `/archives` `GET`, but only the Archiver is using that, and it will be addressed shortly.