### PR TITLE
fix(api): refine error message when session refresh token expired

### DIFF
--- a/middleware/access_logic.py
+++ b/middleware/access_logic.py
@@ -334,6 +334,12 @@ def validate_email_handler(
 
 
 def validate_refresh_token(token: str, **kwargs) -> Optional[RefreshAccessInfo]:
+    try:
+        decode_token(token)
+    except ExpiredSignatureError:
+        FlaskResponseManager.abort(
+            code=HTTPStatus.UNAUTHORIZED, message="Refresh token has expired"
+        )
     decoded_refresh_token = decode_token(token)
     token_type: str = decoded_refresh_token["type"]
     # The below is flagged as a false positive through bandit security linting, misidentifying it as a password


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/650

### Description

* `/refresh-session` API endpoint will now provide a clear indication that an access token has expired.

### Testing

* Steps to test this PR, if there are any required.
* For cut-and-dry changes (API updates or interface tweaks), include a screenshot or updated API response to show what correct behavior looks like

### Performance

* If you're adding or heavily modifying a script, estimate how long it should take to run.

### Docs

* Accompanying docs PRs, if applicable

### Breaking Changes

* What functionality, if any, might be broken by this change, which could impact other developers. For example, an environmental variable changing.
