### PR TITLE
feat(api): add permission for github_sync

### DIFF
--- a/alembic/versions/2025_03_15_1634-75d2ecaaa93f_add_github_sync_permission.py
+++ b/alembic/versions/2025_03_15_1634-75d2ecaaa93f_add_github_sync_permission.py
@@ -1,0 +1,38 @@
+"""Add GitHub Sync Permission
+
+Revision ID: 75d2ecaaa93f
+Revises: 9687740397b7
+Create Date: 2025-03-15 16:34:16.139113
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "75d2ecaaa93f"
+down_revision: Union[str, None] = "9687740397b7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add GitHub Sync Permission
+    op.execute(
+        """
+        INSERT INTO permissions (permission_name, description)
+        VALUES ('github_sync', 'Sync Data Requests with GitHub Issues');
+        """
+    )
+
+
+def downgrade() -> None:
+    # Remove GitHub Sync Permission
+    op.execute(
+        """
+        DELETE FROM permissions WHERE permission_name = 'github_sync';
+        """
+    )

--- a/middleware/enums.py
+++ b/middleware/enums.py
@@ -22,6 +22,7 @@ class PermissionsEnum(Enum):
     SOURCE_COLLECTOR = "source_collector"
     USER_CREATE_UPDATE = "user_create_update"
     ARCHIVE_WRITE = "archive_write"
+    GITHUB_SYNC = "github_sync"
 
     @classmethod
     def values(cls):

--- a/middleware/primary_resource_logic/permissions_logic.py
+++ b/middleware/primary_resource_logic/permissions_logic.py
@@ -1,10 +1,6 @@
-from dataclasses import dataclass
-from enum import Enum
 from http import HTTPStatus
-from typing import Type
 
 from flask import Response, make_response
-from flask_jwt_extended import get_jwt_identity
 from flask_restx import abort
 from marshmallow import Schema, fields
 from pydantic import BaseModel
@@ -80,7 +76,6 @@ class PermissionsManager:
         self.db_client = db_client
         self.user_email = user_email
         self.user_id = user_info.id
-
         self.permissions = self.db_client.get_user_permissions(user_info.id)
 
     def has_permission(self, permission: PermissionsEnum) -> bool:

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/github_issue_app_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/github_issue_app_schemas.py
@@ -68,7 +68,7 @@ class GithubSynchronizeResponseSchema(Schema):
                 description="The urls of the created github issues."
             ),
         ),
-        required=True,
+        required=False,
         metadata=get_json_metadata(
             description="The urls of the created github issues."
         ),

--- a/resources/GithubDataRequests.py
+++ b/resources/GithubDataRequests.py
@@ -1,5 +1,6 @@
-from middleware.access_logic import AccessInfoPrimary, WRITE_ONLY_AUTH_INFO
+from middleware.access_logic import AccessInfoPrimary, AuthenticationInfo
 from middleware.decorators import endpoint_info
+from middleware.enums import AccessTypeEnum, PermissionsEnum
 from middleware.primary_resource_logic.github_issue_app_logic import (
     synchronize_github_issues_with_data_requests,
 )
@@ -16,7 +17,10 @@ class GithubDataRequestsSynchronize(PsycopgResource):
 
     @endpoint_info(
         namespace=namespace_github,
-        auth_info=WRITE_ONLY_AUTH_INFO,
+        auth_info=AuthenticationInfo(
+            allowed_access_methods=[AccessTypeEnum.JWT],
+            restrict_to_permissions=[PermissionsEnum.GITHUB_SYNC],
+        ),
         schema_config=SchemaConfigs.GITHUB_DATA_REQUESTS_SYNCHRONIZE_POST,
         response_info=ResponseInfo(
             success_message="Data requests successfully synchronized."

--- a/tests/helper_scripts/helper_functions_complex.py
+++ b/tests/helper_scripts/helper_functions_complex.py
@@ -187,6 +187,7 @@ def create_admin_test_user_setup(flask_client: FlaskClient) -> TestUserSetup:
             PermissionsEnum.DB_WRITE,
             PermissionsEnum.USER_CREATE_UPDATE,
             PermissionsEnum.ARCHIVE_WRITE,
+            PermissionsEnum.GITHUB_SYNC,
         ],
     )
     return tus_admin

--- a/tests/integration/test_github_data_requests_issues.py
+++ b/tests/integration/test_github_data_requests_issues.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from database_client.db_client_dataclasses import WhereMapping
 from database_client.enums import RequestStatus
 from database_client.models import DataRequest, DataRequestsGithubIssueInfo
-from middleware.enums import Relations
+from middleware.enums import Relations, PermissionsEnum
 from middleware.schema_and_dto_logic.common_response_schemas import MessageSchema
 from middleware.third_party_interaction_logic.github_issue_api_logic import (
     GithubIssueInfo,
@@ -27,6 +27,7 @@ from tests.helper_scripts.constants import (
     GITHUB_DATA_REQUESTS_SYNCHRONIZE,
 )
 from tests.helper_scripts.helper_classes.TestUserSetup import TestUserSetup
+from tests.helper_scripts.helper_functions_complex import create_test_user_setup
 from tests.helper_scripts.run_and_validate_request import run_and_validate_request
 from tests.conftest import (
     clear_data_requests,
@@ -42,6 +43,25 @@ PATCH_ROOT = "middleware.primary_resource_logic.github_issue_app_logic"
 class SynchronizeTestInfo(BaseModel):
     data_request_id: int
     github_issue_info: GithubIssueInfo
+
+
+def test_synchronize_github_issue_denied(
+    test_data_creator_flask: TestDataCreatorFlask, monkeypatch, clear_data_requests
+):
+    # Give a user every permission except github_sync
+    tdc = test_data_creator_flask
+    tus = create_test_user_setup(
+        tdc.flask_client,
+        permissions=[
+            permission
+            for permission in PermissionsEnum
+            if permission != PermissionsEnum.GITHUB_SYNC
+        ],
+    )
+    return tdc.request_validator.github_data_requests_issues_synchronize(
+        headers=tus.jwt_authorization_header,
+        expected_response_status=HTTPStatus.FORBIDDEN,
+    )
 
 
 def test_synchronize_github_issue(


### PR DESCRIPTION
### Fixes

* Supports https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/299#issuecomment-2405951278

### Description

* Add `github_sync` permission for users
* Set up `/github/data-requests/synchronize` to require a user with `github_sync` permission.

### Testing

* Run tests to confirm functionality

### Performance

* Impact marginal

### Docs

* No documentation changes

### Breaking Changes

* `/github/data-requests/synchronize` now requires `github_sync` permission.