### PR TITLE
feat(app): Create `/proposals/agencies` endpoint

### DIFF
--- a/alembic/versions/2025_03_31_1052-2f6972890d82_update_typeahead_agencies_view_to_.py
+++ b/alembic/versions/2025_03_31_1052-2f6972890d82_update_typeahead_agencies_view_to_.py
@@ -1,0 +1,64 @@
+"""Update typeahead agencies view to filter by approval status
+
+Revision ID: 2f6972890d82
+Revises: 75d2ecaaa93f
+Create Date: 2025-03-31 10:52:22.120095
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "2f6972890d82"
+down_revision: Union[str, None] = "75d2ecaaa93f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS public.typeahead_agencies")
+
+    op.execute(
+        """
+        CREATE MATERIALIZED VIEW IF NOT EXISTS public.typeahead_agencies
+        TABLESPACE pg_default
+        AS
+         SELECT a.id,
+            a.name,
+            a.jurisdiction_type,
+            l.state_iso,
+            l.locality_name AS municipality,
+            l.county_name
+           FROM agencies a
+             LEFT JOIN link_agencies_locations lal ON lal.agency_id = a.id
+             LEFT JOIN locations_expanded l ON lal.location_id = l.id
+             WHERE a.approval_status = 'approved'
+        WITH DATA;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS public.typeahead_agencies")
+
+    op.execute(
+        """
+        CREATE MATERIALIZED VIEW IF NOT EXISTS public.typeahead_agencies
+        TABLESPACE pg_default
+        AS
+         SELECT a.id,
+            a.name,
+            a.jurisdiction_type,
+            l.state_iso,
+            l.locality_name AS municipality,
+            l.county_name
+           FROM agencies a
+             LEFT JOIN link_agencies_locations lal ON lal.agency_id = a.id
+             LEFT JOIN locations_expanded l ON lal.location_id = l.id
+        WITH DATA;
+        """
+    )

--- a/alembic/versions/2025_03_31_1630-c1d862a9a587_add_creator_user_id_to_agencies.py
+++ b/alembic/versions/2025_03_31_1630-c1d862a9a587_add_creator_user_id_to_agencies.py
@@ -1,0 +1,35 @@
+"""Add creator_user_id to agencies
+
+Revision ID: c1d862a9a587
+Revises: 2f6972890d82
+Create Date: 2025-03-31 16:30:15.711834
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c1d862a9a587"
+down_revision: Union[str, None] = "2f6972890d82"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("agencies", sa.Column("creator_user_id", sa.Integer(), nullable=True))
+    # Create a foreign key constraint
+    op.create_foreign_key(
+        "agencies_creator_user_id_fkey",
+        "agencies",
+        "users",
+        ["creator_user_id"],
+        ["id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agencies", "creator_user_id")

--- a/app.py
+++ b/app.py
@@ -26,6 +26,7 @@ from resources.Metrics import namespace_metrics
 from resources.Notifications import namespace_notifications
 from resources.OAuth import namespace_oauth
 from resources.Permissions import namespace_permissions
+from resources.Proposals import namespace_proposals
 from resources.Search import namespace_search
 from resources.Signup import namespace_signup
 from resources.TypeaheadSuggestions import (
@@ -80,6 +81,7 @@ NAMESPACES = [
     namespace_admin,
     namespace_contact,
     namespace_metadata,
+    namespace_proposals,
 ]
 
 MY_PREFIX = "/api"

--- a/database_client/models.py
+++ b/database_client/models.py
@@ -254,8 +254,14 @@ class Agency(Base, CountMetadata):
     agency_created: Mapped[timestamp_tz] = mapped_column(
         server_default=func.current_timestamp()
     )
+    creator_user_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("public.users.id")
+    )
 
     # relationships
+    creator: Mapped["User"] = relationship(
+        argument="User", back_populates="created_agencies", uselist=False
+    )
     locations: Mapped[list["LocationExpanded"]] = relationship(
         argument="LocationExpanded",
         secondary="public.link_agencies_locations",
@@ -695,6 +701,10 @@ class User(Base):
     role: Mapped[Optional[text]]
 
     # Relationships
+    created_agencies = relationship(
+        argument="Agency",
+        back_populates="creator",
+    )
     permissions = relationship(
         argument="Permission",
         secondary="public.user_permissions",

--- a/middleware/primary_resource_logic/agencies.py
+++ b/middleware/primary_resource_logic/agencies.py
@@ -24,6 +24,7 @@ from middleware.schema_and_dto_logic.primary_resource_schemas.agencies_advanced_
 )
 from middleware.schema_and_dto_logic.primary_resource_dtos.agencies_dtos import (
     AgenciesPostDTO,
+    AgenciesGetManyDTO,
 )
 from middleware.schema_and_dto_logic.common_schemas_and_dtos import (
     GetManyBaseDTO,
@@ -35,13 +36,14 @@ SUBQUERY_PARAMS = [SubqueryParameterManager.data_sources()]
 
 
 def get_agencies(
-    db_client: DatabaseClient, access_info: AccessInfoPrimary, dto: GetManyBaseDTO
+    db_client: DatabaseClient, access_info: AccessInfoPrimary, dto: AgenciesGetManyDTO
 ) -> Response:
     """
     Retrieves a paginated list of approved agencies from the database.
 
     :param db_client: The database client object.
     :param page: The page number of results to return.
+    :param dto: The AgenciesGetManyDTO object.
     :return: A response object with the relevant agency information and status code.
     """
 
@@ -52,6 +54,7 @@ def get_agencies(
         page=dto.page,
         limit=dto.limit,
         requested_columns=dto.requested_columns,
+        approval_status=dto.approval_status,
     )
 
     return FlaskResponseManager.make_response(
@@ -116,9 +119,10 @@ AGENCY_POST_MIDDLEWARE_PARAMETERS = MiddlewareParameters(
 def create_agency(
     db_client: DatabaseClient,
     dto: AgenciesPostDTO,
+    access_info: AccessInfoPrimary,
 ) -> Response:
 
-    agency_id = db_client.create_agency(dto)
+    agency_id = db_client.create_agency(dto, user_id=access_info.user_id)
 
     return created_id_response(new_id=str(agency_id), message=f"Agency created.")
 

--- a/middleware/primary_resource_logic/proposals_logic.py
+++ b/middleware/primary_resource_logic/proposals_logic.py
@@ -1,0 +1,18 @@
+from database_client.database_client import DatabaseClient
+from database_client.enums import ApprovalStatus
+from middleware.access_logic import AccessInfoPrimary
+from middleware.common_response_formatting import created_id_response
+from middleware.schema_and_dto_logic.primary_resource_dtos.agencies_dtos import (
+    AgenciesPostDTO,
+)
+
+
+def propose_agency(
+    db_client: DatabaseClient, access_info: AccessInfoPrimary, dto: AgenciesPostDTO
+):
+    dto.agency_info.approval_status = ApprovalStatus.PENDING
+    agency_id = db_client.create_agency(dto, user_id=access_info.user_id)
+
+    return created_id_response(
+        new_id=str(agency_id), message=f"Agency proposal created."
+    )

--- a/middleware/schema_and_dto_logic/primary_resource_dtos/agencies_dtos.py
+++ b/middleware/schema_and_dto_logic/primary_resource_dtos/agencies_dtos.py
@@ -5,6 +5,7 @@ from middleware.enums import JurisdictionType, AgencyType
 from middleware.schema_and_dto_logic.common_schemas_and_dtos import (
     LocationInfoDTO,
     GetByIDBaseDTO,
+    GetManyBaseDTO,
 )
 from pydantic import BaseModel
 
@@ -54,3 +55,7 @@ class RelatedAgencyByIDDTO(GetByIDBaseDTO):
             "data_source_id": int(self.resource_id),
             "agency_id": int(self.agency_id),
         }
+
+
+class AgenciesGetManyDTO(GetManyBaseDTO):
+    approval_status: Optional[ApprovalStatus] = None

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/agencies_base_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/agencies_base_schemas.py
@@ -1,13 +1,17 @@
-from marshmallow import fields, Schema
+from marshmallow import fields, Schema, pre_load
 
-from database_client.enums import ApprovalStatus
+from database_client.enums import ApprovalStatus, RequestStatus
 from middleware.enums import JurisdictionType, AgencyType
+from middleware.schema_and_dto_logic.common_schemas_and_dtos import (
+    GetManyRequestsBaseSchema,
+)
 from middleware.schema_and_dto_logic.primary_resource_schemas.locations_schemas import (
     STATE_ISO_FIELD,
     COUNTY_FIPS_FIELD,
     LOCALITY_NAME_FIELD,
 )
 from middleware.schema_and_dto_logic.enums import CSVColumnCondition
+from middleware.schema_and_dto_logic.util import get_query_metadata
 from utilities.enums import SourceMappingEnum
 
 
@@ -189,22 +193,12 @@ class AgenciesExpandedSchema(AgencyInfoBaseSchema):
             "source": SourceMappingEnum.JSON,
         },
     )
-    state_iso = STATE_ISO_FIELD
-    state_name = fields.Str(
-        required=False,
+
+
+class GetManyAgenciesRequestsSchema(GetManyRequestsBaseSchema):
+    approval_status = fields.Enum(
+        enum=ApprovalStatus,
+        by_value=fields.Str,
         allow_none=True,
-        metadata={
-            "description": "The name of the state in which the agency is located. Does not apply to federal agencies",
-            "source": SourceMappingEnum.JSON,
-        },
+        metadata=get_query_metadata("The approval status of the agencies to return."),
     )
-    county_name = fields.Str(
-        required=False,
-        allow_none=True,
-        metadata={
-            "description": "The name of the county in which the agency is located.",
-            "source": SourceMappingEnum.JSON,
-        },
-    )
-    county_fips = COUNTY_FIPS_FIELD
-    locality_name = LOCALITY_NAME_FIELD

--- a/resources/Agencies.py
+++ b/resources/Agencies.py
@@ -59,7 +59,7 @@ class AgenciesByPage(PsycopgResource):
         """
         return self.run_endpoint(
             wrapper_function=get_agencies,
-            schema_populate_parameters=GET_MANY_SCHEMA_POPULATE_PARAMETERS,
+            schema_populate_parameters=SchemaConfigs.AGENCIES_GET_MANY.value.get_schema_populate_parameters(),
             access_info=access_info,
         )
 
@@ -75,6 +75,7 @@ class AgenciesByPage(PsycopgResource):
         return self.run_endpoint(
             wrapper_function=create_agency,
             schema_populate_parameters=SchemaConfigs.AGENCIES_POST.value.get_schema_populate_parameters(),
+            access_info=access_info,
         )
 
 

--- a/resources/Proposals.py
+++ b/resources/Proposals.py
@@ -1,0 +1,29 @@
+from middleware.access_logic import AccessInfoPrimary
+from middleware.authentication_info import STANDARD_JWT_AUTH_INFO
+from middleware.decorators import endpoint_info
+from middleware.primary_resource_logic.proposals_logic import propose_agency
+from resources.PsycopgResource import PsycopgResource
+from resources.endpoint_schema_config import SchemaConfigs
+from resources.resource_helpers import ResponseInfo
+from utilities.namespace import create_namespace, AppNamespaces
+
+namespace_proposals = create_namespace(AppNamespaces.PROPOSALS)
+
+
+@namespace_proposals.route("/agencies", methods=["POST"])
+class ProposalsAgencies(PsycopgResource):
+
+    @endpoint_info(
+        namespace=namespace_proposals,
+        endpoint_description="Submit a proposal for an agency",
+        auth_info=STANDARD_JWT_AUTH_INFO,
+        schema_config=SchemaConfigs.PROPOSAL_AGENCIES_POST,
+        response_info=ResponseInfo(success_message="Proposal successfully submitted."),
+        description="Submit a proposal for an agency",
+    )
+    def post(self, access_info: AccessInfoPrimary):
+        return self.run_endpoint(
+            wrapper_function=propose_agency,
+            schema_populate_parameters=SchemaConfigs.PROPOSAL_AGENCIES_POST.value.get_schema_populate_parameters(),
+            access_info=access_info,
+        )

--- a/resources/endpoint_schema_config.py
+++ b/resources/endpoint_schema_config.py
@@ -2,7 +2,7 @@ from enum import Enum
 from http import HTTPStatus
 from typing import Optional, Type
 
-from marshmallow import Schema
+from marshmallow import Schema, RAISE
 
 from middleware.primary_resource_logic.github_oauth_logic import (
     LinkToGithubRequestDTO,
@@ -36,6 +36,9 @@ from middleware.schema_and_dto_logic.primary_resource_schemas.admin_schemas impo
     AdminUsersPutSchema,
     AdminUsersPostSchema,
     AdminUsersGetManyResponseSchema,
+)
+from middleware.schema_and_dto_logic.primary_resource_schemas.agencies_base_schemas import (
+    GetManyAgenciesRequestsSchema,
 )
 from middleware.schema_and_dto_logic.primary_resource_schemas.archives_schemas import (
     ArchivesGetResponseSchema,
@@ -152,6 +155,7 @@ from middleware.schema_and_dto_logic.primary_resource_schemas.agencies_advanced_
 from middleware.schema_and_dto_logic.primary_resource_dtos.agencies_dtos import (
     AgenciesPostDTO,
     RelatedAgencyByIDDTO,
+    AgenciesGetManyDTO,
 )
 from middleware.schema_and_dto_logic.primary_resource_schemas.data_requests_advanced_schemas import (
     GetManyDataRequestsResponseSchema,
@@ -366,9 +370,9 @@ class SchemaConfigs(Enum):
         primary_output_schema=AgenciesGetByIDResponseSchema(),
     )
     AGENCIES_GET_MANY = EndpointSchemaConfig(
-        input_schema=GetManyRequestsBaseSchema(),
+        input_schema=GetManyAgenciesRequestsSchema(),
         primary_output_schema=AgenciesGetManyResponseSchema(),
-        input_dto_class=GetManyBaseDTO,
+        input_dto_class=AgenciesGetManyDTO,
     )
     AGENCIES_POST = get_post_resource_endpoint_schema_config(
         input_schema=AgenciesPostSchema(),
@@ -633,4 +637,18 @@ class SchemaConfigs(Enum):
     # region Metadata
     RECORD_TYPE_AND_CATEGORY_GET = EndpointSchemaConfig(
         primary_output_schema=RecordTypeAndCategoryResponseSchema(),
+    )
+    # endregion
+
+    PROPOSAL_AGENCIES_POST = EndpointSchemaConfig(
+        input_schema=AgenciesPostSchema(
+            exclude=[
+                "agency_info.approval_status",
+                "agency_info.last_approval_editor",
+                "agency_info.submitter_contact",
+                "agency_info.rejection_reason",
+            ],
+            unknown=RAISE,
+        ),
+        input_dto_class=AgenciesPostDTO,
     )

--- a/tests/helper_scripts/helper_classes/TestDataCreatorFlask.py
+++ b/tests/helper_scripts/helper_classes/TestDataCreatorFlask.py
@@ -3,7 +3,7 @@ from typing import Optional
 from flask.testing import FlaskClient
 
 from database_client.database_client import DatabaseClient
-from database_client.enums import RequestStatus
+from database_client.enums import RequestStatus, ApprovalStatus
 from middleware.enums import JurisdictionType, PermissionsEnum, AgencyType
 from middleware.schema_and_dto_logic.primary_resource_schemas.agencies_advanced_schemas import (
     AgencyInfoPostSchema,
@@ -121,6 +121,7 @@ class TestDataCreatorFlask:
         locality_name,
         jurisdiction_type: JurisdictionType,
         location_ids: Optional[list[dict]] = None,
+        approval_status: ApprovalStatus = ApprovalStatus.APPROVED,
     ) -> dict:
         if location_ids is None:
             location_id = self.locality(
@@ -134,6 +135,7 @@ class TestDataCreatorFlask:
                     "name": name,
                     "jurisdiction_type": JurisdictionType.LOCAL.value,
                     "agency_type": AgencyType.POLICE.value,
+                    "approval_status": approval_status.value,
                 },
             ),
             "location_ids": location_ids,
@@ -144,6 +146,7 @@ class TestDataCreatorFlask:
         location_ids: Optional[list[dict]] = None,
         agency_name: str = "",
         add_test_name: bool = True,
+        approval_status: ApprovalStatus = ApprovalStatus.APPROVED,
     ) -> TestAgencyInfo:
         if add_test_name and agency_name == "":
             submitted_name = self.tdcdb.test_name(agency_name)
@@ -155,6 +158,7 @@ class TestDataCreatorFlask:
             locality_name=locality_name,
             jurisdiction_type=JurisdictionType.LOCAL,
             location_ids=location_ids,
+            approval_status=approval_status,
         )
 
         json = run_and_validate_request(

--- a/tests/helper_scripts/helper_functions_complex.py
+++ b/tests/helper_scripts/helper_functions_complex.py
@@ -11,6 +11,7 @@ from werkzeug.security import generate_password_hash
 
 from database_client.database_client import DatabaseClient
 from database_client.db_client_dataclasses import WhereMapping
+from database_client.enums import ApprovalStatus
 from middleware.enums import (
     PermissionsEnum,
     Relations,
@@ -140,6 +141,7 @@ def setup_get_typeahead_suggestion_test_data(cursor: Optional[psycopg.Cursor] = 
                     name="Xylodammerung Police Agency",
                     jurisdiction_type=JurisdictionType.STATE,
                     agency_type=AgencyType.POLICE,
+                    approval_status=ApprovalStatus.APPROVED,
                 ),
                 location_ids=[location_id],
             )

--- a/tests/integration/test_proposals.py
+++ b/tests/integration/test_proposals.py
@@ -1,0 +1,72 @@
+from http import HTTPStatus
+from http.client import HTTPException
+
+import pytest
+
+from database_client.enums import ApprovalStatus
+from database_client.models import Agency, LinkAgencyLocation
+from middleware.enums import JurisdictionType, AgencyType
+from tests.helper_scripts.helper_classes.TestDataCreatorFlask import (
+    TestDataCreatorFlask,
+)
+
+
+def test_proposal_agency_create(test_data_creator_flask: TestDataCreatorFlask):
+    tdc = test_data_creator_flask
+    tdc.clear_test_data()
+    location_id = tdc.locality()
+
+    tdc.request_validator.create_proposal_agency(
+        headers=tdc.get_admin_tus().jwt_authorization_header,
+        data={
+            "agency_info": {
+                "name": "Test Agency",
+                "jurisdiction_type": JurisdictionType.LOCAL.value,
+                "agency_type": AgencyType.COURT.value,
+                "homepage_url": "https://example.com",
+            },
+            "location_ids": [location_id],
+        },
+    )
+
+    # Confirm agency in database
+    agencies = tdc.db_client.get_all(Agency)
+    assert len(agencies) == 1
+    assert agencies[0]["name"] == "Test Agency"
+    assert agencies[0]["jurisdiction_type"] == JurisdictionType.LOCAL.value
+    assert agencies[0]["agency_type"] == AgencyType.COURT.value
+    assert agencies[0]["homepage_url"] == "https://example.com"
+    assert agencies[0]["creator_user_id"] == tdc.get_admin_tus().user_info.user_id
+    assert agencies[0]["approval_status"] == ApprovalStatus.PENDING.value
+
+    # Confirm agency location link in database
+    links = tdc.db_client.get_all(LinkAgencyLocation)
+    assert len(links) == 1
+    assert links[0]["agency_id"] == agencies[0]["id"]
+    assert links[0]["location_id"] == location_id
+
+
+def test_proposal_agency_create_fail_on_approval_status_included(
+    test_data_creator_flask: TestDataCreatorFlask,
+):
+    tdc = test_data_creator_flask
+    tdc.clear_test_data()
+    location_id = tdc.locality()
+
+    tdc.request_validator.create_proposal_agency(
+        headers=tdc.get_admin_tus().jwt_authorization_header,
+        data={
+            "agency_info": {
+                "name": "Test Agency",
+                "jurisdiction_type": JurisdictionType.LOCAL.value,
+                "agency_type": AgencyType.COURT.value,
+                "homepage_url": "https://example.com",
+                "approval_status": ApprovalStatus.APPROVED.value,
+            },
+            "location_ids": [location_id],
+        },
+        expected_json_content={
+            "message": "{'agency_info': {'approval_status': ['Unknown field.']}}"
+        },
+        expected_response_status=HTTPStatus.BAD_REQUEST,
+    )

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -865,6 +865,8 @@ def test_agencies_table_logic(test_data_creator_db_client: TestDataCreatorDBClie
     db_client = tdc.db_client
     delete_change_log(db_client)
 
+    NUMBER_OF_AGENCY_TABLE_COLUMNS = 18
+
     # Create agency
     old_name = get_test_name()
     new_name = get_test_name()
@@ -897,5 +899,5 @@ def test_agencies_table_logic(test_data_creator_db_client: TestDataCreatorDBClie
     log = logs[2]
     assert log["operation_type"] == OperationType.DELETE.value
     assert log["affected_id"] == agency_info.id
-    assert len(log["old_data"].keys()) == 17
+    assert len(log["old_data"].keys()) == NUMBER_OF_AGENCY_TABLE_COLUMNS
     assert log["new_data"] is None

--- a/utilities/namespace.py
+++ b/utilities/namespace.py
@@ -36,6 +36,7 @@ class AppNamespaces(Enum):
     ADMIN = NamespaceAttributes(path="admin", description="Admin Namespace")
     CONTACT = NamespaceAttributes(path="contact", description="Contact Namespace")
     METADATA = NamespaceAttributes(path="metadata", description="Metadata Namespace")
+    PROPOSALS = NamespaceAttributes(path="proposals", description="Proposals Namespace")
 
 
 def create_namespace(


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/693#issuecomment-2764646452

### Description

* Create `/proposals/agencies` endpoint, allowing any user to submit a proposal for a new agency
* Add `creator_user_id` column to `agencies` table in database
* Update `/typeahead/agencies` to only show approved agencies (previously, it was showing all agencies).

### Testing

* Run tests to confirm functionality

### Performance

* Increase in test overhead
* Separate endpoint whose performance is distinct from others
* Otherwise, impact marginal

### Docs

* New API documentation for `/proposals/agencies` endpoint

### Breaking Changes

* No breaking changes.