### PR TITLE
feat(api): Add `data-sources/{id}/reject` endpoint

### DIFF
--- a/database_client/database_client.py
+++ b/database_client/database_client.py
@@ -2108,6 +2108,15 @@ class DatabaseClient:
 
         return {"record_types": record_types, "record_categories": record_categories}
 
+    def reject_data_source(self, data_source_id: int, rejection_note: str):
+        self.update_data_source(
+            entry_id=data_source_id,
+            column_edit_mappings={
+                "approval_status": ApprovalStatus.REJECTED.value,
+                "rejection_note": rejection_note,
+            },
+        )
+
     @session_manager
     def get_all(self, model: Type[Base]):
 

--- a/middleware/primary_resource_logic/data_sources_logic.py
+++ b/middleware/primary_resource_logic/data_sources_logic.py
@@ -5,21 +5,17 @@ from flask import make_response, Response
 from pydantic import BaseModel
 
 from database_client.database_client import DatabaseClient
-from database_client.db_client_dataclasses import OrderByParameters, WhereMapping
-from database_client.subquery_logic import SubqueryParameters, SubqueryParameterManager
+from database_client.db_client_dataclasses import OrderByParameters
+from database_client.subquery_logic import SubqueryParameterManager
 from database_client.enums import ApprovalStatus, RelationRoleEnum, ColumnPermissionEnum
 from database_client.result_formatter import ResultFormatter
 from middleware.access_logic import AccessInfoPrimary
 from middleware.column_permission_logic import get_permitted_columns
 from middleware.dynamic_request_logic.delete_logic import delete_entry
-from middleware.dynamic_request_logic.get_by_id_logic import get_by_id
 from middleware.dynamic_request_logic.get_many_logic import (
     optionally_limit_to_requested_columns,
 )
-from middleware.dynamic_request_logic.get_related_resource_logic import (
-    GetRelatedResourcesParameters,
-    get_related_resource,
-)
+
 from middleware.dynamic_request_logic.post_logic import (
     PostLogic,
     PostHandler,
@@ -46,6 +42,7 @@ from middleware.common_response_formatting import format_list_response, message_
 from middleware.schema_and_dto_logic.primary_resource_dtos.data_sources_dtos import (
     DataSourcesPostDTO,
     DataSourcesPutDTO,
+    DataSourcesRejectDTO,
 )
 from middleware.util import dataclass_to_filtered_dict
 
@@ -376,6 +373,20 @@ def delete_data_source_related_agency(
             additional_where_mappings=dto.get_where_mapping(),
         ),
     )
+
+
+# endregion
+
+
+# region Reject Data Source
+def reject_data_source(
+    db_client: DatabaseClient,
+    dto: DataSourcesRejectDTO,
+) -> Response:
+    db_client.reject_data_source(
+        data_source_id=int(dto.resource_id), rejection_note=dto.rejection_note
+    )
+    return message_response("Successfully rejected data source.")
 
 
 # endregion

--- a/middleware/schema_and_dto_logic/primary_resource_dtos/data_sources_dtos.py
+++ b/middleware/schema_and_dto_logic/primary_resource_dtos/data_sources_dtos.py
@@ -87,3 +87,8 @@ class DataSourcesPutDTO(BaseModel):
 class DataSourcesPostDTO(BaseModel):
     entry_data: DataSourceEntryDataPostDTO
     linked_agency_ids: Optional[List[int]] = None
+
+
+class DataSourcesRejectDTO(BaseModel):
+    resource_id: int
+    rejection_note: str

--- a/middleware/schema_and_dto_logic/primary_resource_schemas/data_sources_base_schemas.py
+++ b/middleware/schema_and_dto_logic/primary_resource_schemas/data_sources_base_schemas.py
@@ -10,6 +10,7 @@ from database_client.enums import (
     ApprovalStatus,
 )
 from middleware.enums import RecordTypes
+from middleware.schema_and_dto_logic.common_schemas_and_dtos import GetByIDBaseSchema
 from middleware.schema_and_dto_logic.enums import CSVColumnCondition
 from middleware.schema_and_dto_logic.util import get_json_metadata
 
@@ -327,3 +328,9 @@ class DataSourcesMapResponseInnerSchema(Schema):
     record_type = fields.String(metadata=get_json_metadata("The type of the record"))
     lat = fields.Float(metadata=get_json_metadata("The latitude of the data source"))
     lng = fields.Float(metadata=get_json_metadata("The longitude of the data source"))
+
+
+class DataSourceRejectSchema(GetByIDBaseSchema):
+    rejection_note = fields.String(
+        metadata=get_json_metadata("Why the note was rejected.")
+    )

--- a/resources/DataSources.py
+++ b/resources/DataSources.py
@@ -28,6 +28,7 @@ from middleware.primary_resource_logic.data_sources_logic import (
     create_data_source_related_agency,
     delete_data_source_related_agency,
     get_data_source_related_agencies,
+    reject_data_source,
 )
 
 from middleware.schema_and_dto_logic.primary_resource_schemas.data_sources_advanced_schemas import (
@@ -263,3 +264,26 @@ class DataSourcesRelatedAgenciesById(PsycopgResource):
 
 
 # endregion
+
+# region Reject
+
+
+@namespace_data_source.route("/<resource_id>/reject")
+class DataSourcesRejectByID(PsycopgResource):
+    @endpoint_info(
+        namespace=namespace_data_source,
+        auth_info=WRITE_ONLY_AUTH_INFO,
+        schema_config=SchemaConfigs.DATA_SOURCES_BY_ID_REJECT,
+        response_info=ResponseInfo(
+            success_message="Data source successfully rejected.",
+        ),
+        description="Reject a data source",
+    )
+    def post(self, access_info: AccessInfoPrimary, resource_id: str) -> Response:
+        """
+        Reject a data source
+        """
+        return self.run_endpoint(
+            wrapper_function=reject_data_source,
+            schema_populate_parameters=SchemaConfigs.DATA_SOURCES_BY_ID_REJECT.value.get_schema_populate_parameters(),
+        )

--- a/resources/endpoint_schema_config.py
+++ b/resources/endpoint_schema_config.py
@@ -54,6 +54,9 @@ from middleware.schema_and_dto_logic.primary_resource_schemas.bulk_schemas impor
 from middleware.schema_and_dto_logic.primary_resource_schemas.contact_schemas import (
     ContactFormPostSchema,
 )
+from middleware.schema_and_dto_logic.primary_resource_schemas.data_sources_base_schemas import (
+    DataSourceRejectSchema,
+)
 from middleware.schema_and_dto_logic.primary_resource_schemas.locations_schemas import (
     GetLocationInfoByIDResponseSchema,
 )
@@ -178,6 +181,7 @@ from middleware.schema_and_dto_logic.primary_resource_schemas.data_sources_advan
 )
 from middleware.schema_and_dto_logic.primary_resource_dtos.data_sources_dtos import (
     DataSourcesPostDTO,
+    DataSourcesRejectDTO,
 )
 from middleware.schema_and_dto_logic.common_response_schemas import (
     IDAndMessageSchema,
@@ -419,6 +423,11 @@ class SchemaConfigs(Enum):
     )
     DATA_SOURCES_RELATED_AGENCIES_POST = DATA_SOURCES_RELATED_AGENCY_BY_ID
     DATA_SOURCES_RELATED_AGENCIES_DELETE = DATA_SOURCES_RELATED_AGENCY_BY_ID
+    DATA_SOURCES_BY_ID_REJECT = EndpointSchemaConfig(
+        input_schema=DataSourceRejectSchema(),
+        input_dto_class=DataSourcesRejectDTO,
+        primary_output_schema=MessageSchema(),
+    )
     # endregion
 
     # region Github

--- a/tests/helper_scripts/helper_classes/RequestValidator.py
+++ b/tests/helper_scripts/helper_classes/RequestValidator.py
@@ -867,3 +867,21 @@ class RequestValidator:
             expected_response_status=expected_response_status,
             expected_json_content=expected_json_content,
         )
+
+    def reject_data_source(
+        self,
+        headers: dict,
+        data_source_id: int,
+        rejection_note: str,
+        expected_response_status: HTTPStatus = HTTPStatus.OK,
+        expected_json_content: Optional[dict] = None,
+        expected_schema: Schema = SchemaConfigs.DATA_SOURCES_BY_ID_REJECT.value.primary_output_schema,
+    ):
+        return self.post(
+            endpoint=f"/api/data-sources/{data_source_id}/reject",
+            headers=headers,
+            json={"rejection_note": rejection_note},
+            expected_schema=expected_schema,
+            expected_response_status=expected_response_status,
+            expected_json_content=expected_json_content,
+        )


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/700

### Description

* Add standalone admin-only endpoint for rejecting data sources.

### Testing

* Run tests and confirm functionality 

### Performance

* Separate endpoint with separate performance impact
* Increase in test overhead
* Impact marginal

### Docs

* New endpoint documented in API documentation

### Breaking Changes

* No breaking changes