### PR TITLE
mc_786_ruff

### DIFF
--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -3,23 +3,6 @@ name: flake8 Lint
 on: [pull_request]
 
 jobs:
-  flake8-lint:
-    runs-on: ubuntu-latest
-    name: Lint
-    steps:
-      - name: Check out source repository
-        uses: actions/checkout@v4
-      - name: Set up Python environment
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - run: pip install flake8 flake8-docstrings flake8-simplify flake8-unused-arguments flake8-annotations
-      - name: flake8 Lint with Reviewdog
-        uses: reviewdog/action-flake8@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          flake8_args: --ignore E501,W291  # Does not check for max line exceed or trailing whitespace
-          level: warning
   based-pyright:
     runs-on: ubuntu-latest
     name: Pyright Lint


### PR DESCRIPTION
### Fixes

https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/786

### Description

* Removes reviewdog linter, now supplanted by ruff (and largely producing unused notifications)

### Testing

* Run tests and confirm functionality 

### Performance

* Will reduce GitHub Action runtime

### Docs

* No changes to documentation 

### Breaking Changes

* No breaking changes 