### PR TITLE
Add logic for preventing approval of data sources with null record types

### DIFF
--- a/alembic/versions/2025_07_05_1439-9689f73c0938_add_check_for_approval_status_and_.py
+++ b/alembic/versions/2025_07_05_1439-9689f73c0938_add_check_for_approval_status_and_.py
@@ -1,0 +1,34 @@
+"""Add check for approval status and record_type_id
+
+Revision ID: 9689f73c0938
+Revises: 2970f0ba9eee
+Create Date: 2025-07-05 14:39:10.592108
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '9689f73c0938'
+down_revision: Union[str, None] = '2970f0ba9eee'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+CONSTRAINT_NAME = 'check_for_approval_status_and_record_type_id'
+TABLE_NAME = 'data_sources'
+
+def upgrade() -> None:
+    op.create_check_constraint(
+        CONSTRAINT_NAME,
+        TABLE_NAME,
+        'approval_status != \'approved\' OR record_type_id IS NOT NULL'
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        CONSTRAINT_NAME,
+        TABLE_NAME,
+        type_='check'
+    )

--- a/db/queries/instantiations/data_sources/post/single.py
+++ b/db/queries/instantiations/data_sources/post/single.py
@@ -75,7 +75,7 @@ class DataSourcesPostSingleQueryBuilder(
             rejection_note=entry.rejection_note,
             last_approval_editor=entry.last_approval_editor,
             broken_source_url_as_of=entry.broken_source_url_as_of,
-            record_type_id=self._get_record_type_id(entry.record_type_name.value),
+            record_type_id=self._get_record_type_id(entry.record_type_name.value) if entry.record_type_name is not None else None,
         )
         self.session.add(data_source)
 

--- a/tests/helper_scripts/helper_classes/RequestValidator.py
+++ b/tests/helper_scripts/helper_classes/RequestValidator.py
@@ -165,6 +165,7 @@ from tests.helper_scripts.constants import (
     DATA_REQUESTS_POST_DELETE_RELATED_LOCATIONS_ENDPOINT,
     DATA_SOURCES_BASE_ENDPOINT,
 )
+from tests.helper_scripts.helper_classes.TestUserSetup import TestUserSetup
 from tests.helper_scripts.helper_functions_simple import (
     get_authorization_header,
     add_query_params,
@@ -891,6 +892,22 @@ class RequestValidator:
             query_parameters=query_params,
             headers=headers,
             expected_schema=DataSourcesGetManyEndpointSchemaConfig.primary_output_schema,
+        )
+
+    def update_data_source(
+        self,
+        tus: TestUserSetup,
+        data_source_id: int,
+        entry_data: dict,
+        expected_response_status: HTTPStatus = HTTPStatus.OK,
+        expected_json_content: Optional[dict] = None,
+    ):
+        return self.put(
+            endpoint=f"/api/data-sources/{data_source_id}",
+            headers=tus.jwt_authorization_header,
+            json={"entry_data": entry_data},
+            expected_response_status=expected_response_status,
+            expected_json_content=expected_json_content,
         )
 
     def get_agency_by_id(self, headers: dict, id: int):

--- a/tests/helper_scripts/helper_classes/test_data_creator/db_client_/core.py
+++ b/tests/helper_scripts/helper_classes/test_data_creator/db_client_/core.py
@@ -178,7 +178,7 @@ class TestDataCreatorDBClient:
     def data_source(
         self,
         approval_status: ApprovalStatus = ApprovalStatus.APPROVED,
-        record_type: RecordTypes = RecordTypes.ACCIDENT_REPORTS,
+        record_type: RecordTypes | None = RecordTypes.ACCIDENT_REPORTS,
         source_url: str | None = None,
     ) -> CreatedDataSource:
         dto = DataSourcesPostDTO(

--- a/tests/integration/data_sources/put/test_approve_without_record_id.py
+++ b/tests/integration/data_sources/put/test_approve_without_record_id.py
@@ -1,0 +1,28 @@
+from http import HTTPStatus
+
+from db.enums import ApprovalStatus
+from tests.helper_scripts.helper_classes.test_data_creator.flask import TestDataCreatorFlask
+
+
+def test_data_sources_by_id_put_approve_without_record_id(
+    test_data_creator_flask: TestDataCreatorFlask,
+):
+    """
+    Test that the data source can't be approved without a record id
+    """
+
+    # Arrange
+    tdc = test_data_creator_flask
+    data_source_id = tdc.tdcdb.data_source(
+        approval_status=ApprovalStatus.PENDING,
+        record_type=None
+    ).id
+
+    tdc.request_validator.update_data_source(
+        tus=tdc.get_admin_tus(),
+        data_source_id=data_source_id,
+        entry_data={"approval_status": ApprovalStatus.APPROVED.value},
+        expected_response_status=HTTPStatus.BAD_REQUEST,
+        expected_json_content={"message": "Record type is required for approval."},
+    )
+

--- a/tests/integration/data_sources/put/test_basic.py
+++ b/tests/integration/data_sources/put/test_basic.py
@@ -62,13 +62,12 @@ def test_data_sources_by_id_put(test_data_creator_flask: TestDataCreatorFlask):
         "record_type_name": RecordTypes.ARREST_RECORDS.value,
     }
 
-    run_and_validate_request(
-        flask_client=tdc.flask_client,
-        http_method="put",
-        endpoint=f"/api/data-sources/{cdr.id}",
-        headers=tdc.get_admin_tus().jwt_authorization_header,
-        json={"entry_data": entry_data},
+    tdc.request_validator.update_data_source(
+        tus=tdc.get_admin_tus(),
+        data_source_id=cdr.id,
+        entry_data=entry_data,
     )
+
 
     response_json = run_and_validate_request(
         flask_client=tdc.flask_client,


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-source-identification/issues/323

### Description

* Updates `/data-sources/{id}` `PUT` logic such that attempts to change approval status to `approved` without the `record_type` being set will yield a specific error.

### Testing

* Additional test added to test for this logic.

### Performance

* Impact marginal

### Docs

* No documentation changes 

### Breaking Changes

* No breaking changes