### PR TITLE
Tweak ops notifications

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,12 @@ All unit and integration tests for the API live in the `tests` folder
 It is best practice to add tests for any new feature to ensure it is working as expected and that any future code changes do not affect its functionality. All tests will be automatically run when a PR into dev is opened in order to ensure any changes do not break current app functionality. If a test fails, it is a sign that the new code should be checked or possibly that the test needs to be updated. 
 
 ## Linting
-Linting is enforced with black on PR creation. You can use black to automatically reformat your files before commiting them, this will allow your PR to pass this check. Any files that require reformatting will be listed on any failed checks on the PR.
+Linting is enforced with ruff on PR creation. You can use ruff to automatically reformat your files before commiting them, which will allow your PR to pass this check. Any files that require reformatting will be listed on any failed checks on the PR.
 ```
-black app_test.py
+ruff check .              # Lint
+ruff check --fix .        # Lint and auto-fix issues
+ruff format --check .     # Check if formatting needed
+ruff format .             # Format code
 ```
 
 ## Docstring and Type Checking

--- a/middleware/primary_resource_logic/data_requests_/post.py
+++ b/middleware/primary_resource_logic/data_requests_/post.py
@@ -13,10 +13,12 @@ def create_data_request_wrapper(
 ) -> Response:
     dr_id = db_client.create_data_request_v2(dto=dto, user_id=access_info.get_user_id())
 
-    send_via_mailgun(
-        to_email=OPERATIONS_EMAIL,
-        subject=f"New data request submitted: {dto.request_info.title}",
-        text=f"Submission notes: \n\n{dto.request_info.submission_notes}",
-    )
+    # Only send email if notifications are enabled
+    if os.getenv('SEND_OPS_NOTIFICATIONS', 'false').lower() == 'true':
+        send_via_mailgun(
+            to_email=OPERATIONS_EMAIL,
+            subject=f"New data request submitted: {dto.request_info.title}",
+            text=f"Submission notes: \n\n{dto.request_info.submission_notes}",
+        )
 
     return created_id_response(new_id=str(dr_id), message="Data request created.")

--- a/middleware/primary_resource_logic/data_requests_/post.py
+++ b/middleware/primary_resource_logic/data_requests_/post.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Response
 
 from db.client.core import DatabaseClient
@@ -14,7 +16,7 @@ def create_data_request_wrapper(
     dr_id = db_client.create_data_request_v2(dto=dto, user_id=access_info.get_user_id())
 
     # Only send email if notifications are enabled
-    if os.getenv('SEND_OPS_NOTIFICATIONS', 'false').lower() == 'true':
+    if os.getenv("SEND_OPS_NOTIFICATIONS", "false").lower() == "true":
         send_via_mailgun(
             to_email=OPERATIONS_EMAIL,
             subject=f"New data request submitted: {dto.request_info.title}",

--- a/middleware/primary_resource_logic/data_sources.py
+++ b/middleware/primary_resource_logic/data_sources.py
@@ -1,3 +1,5 @@
+import os
+
 from typing import Optional
 
 from flask import make_response, Response
@@ -191,9 +193,9 @@ def add_new_data_source_wrapper(
     db_client: DatabaseClient, dto: DataSourcesPostDTO, access_info: AccessInfoPrimary
 ) -> Response:
     data_source_id = db_client.add_data_source_v2(dto)
-    
+
     # Only send email if notifications are enabled
-    if os.getenv('SEND_OPS_NOTIFICATIONS', 'false').lower() == 'true':
+    if os.getenv("SEND_OPS_NOTIFICATIONS", "false").lower() == "true":
         send_via_mailgun(
             to_email=OPERATIONS_EMAIL,
             subject=f"New data source submitted: {dto.entry_data.name}",

--- a/middleware/primary_resource_logic/data_sources.py
+++ b/middleware/primary_resource_logic/data_sources.py
@@ -191,11 +191,14 @@ def add_new_data_source_wrapper(
     db_client: DatabaseClient, dto: DataSourcesPostDTO, access_info: AccessInfoPrimary
 ) -> Response:
     data_source_id = db_client.add_data_source_v2(dto)
-    send_via_mailgun(
-        to_email=OPERATIONS_EMAIL,
-        subject=f"New data source submitted: {dto.entry_data.name}",
-        text=f"Description: \n\n{dto.entry_data.description}",
-    )
+    
+    # Only send email if notifications are enabled
+    if os.getenv('SEND_OPS_NOTIFICATIONS', 'false').lower() == 'true':
+        send_via_mailgun(
+            to_email=OPERATIONS_EMAIL,
+            subject=f"New data source submitted: {dto.entry_data.name}",
+            text=f"Description: \n\n{dto.entry_data.description}",
+        )
 
     return make_response(
         {

--- a/tests/integration/data_sources/test_post.py
+++ b/tests/integration/data_sources/test_post.py
@@ -18,7 +18,10 @@ from tests.helper_scripts.helper_classes.test_data_creator.flask import (
 )
 from tests.helper_scripts.run_and_validate_request import run_and_validate_request
 
+from unittest.mock import patch
 
+
+@patch.dict('os.environ', {'SEND_OPS_NOTIFICATIONS': 'true'})
 def test_data_sources_post(
     test_data_creator_flask: TestDataCreatorFlask, mock_send_via_mailgun
 ):

--- a/tests/integration/test_data_requests.py
+++ b/tests/integration/test_data_requests.py
@@ -37,6 +37,7 @@ from tests.helper_scripts.helper_classes.test_data_creator.flask import (
 )
 from tests.helper_scripts.run_and_validate_request import run_and_validate_request
 
+from unittest.mock import patch
 
 def test_data_requests_get(
     test_data_creator_flask: TestDataCreatorFlask,
@@ -133,7 +134,7 @@ def test_data_requests_get(
 
     assert len(data) == 1
 
-
+@patch.dict('os.environ', {'SEND_OPS_NOTIFICATIONS': 'true'})
 def test_data_requests_post(
     test_data_creator_flask: TestDataCreatorFlask, mock_send_via_mailgun
 ):


### PR DESCRIPTION
Fixes
https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/813
Description
References a new envar to determine if "ops notifications" are on. I already added the envar on prod and dev.

I wasn't positive where to modify the logic—this could be gated at other points (turning off all mailgun notifications, for example) but I decided to limit each notification individually, rather than accidentally turning off future notifications in a confusing way.

Testing
I wasn't sure how to test this locally, and my local env is not working. Perhaps we could change the envar on dev and see?