### PR TITLE
Fix bug forbidding null descriptions

### DIFF
--- a/endpoints/instantiations/source_collector/data_sources/sync/dtos/response.py
+++ b/endpoints/instantiations/source_collector/data_sources/sync/dtos/response.py
@@ -1,5 +1,6 @@
 # pyright: reportUnknownVariableType = false
 from datetime import datetime
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -12,7 +13,7 @@ class SourceCollectorSyncDataSourcesResponseInnerDTO(BaseModel):
     id: int = default_field_required(description="The id of the data source.")
     url: str = default_field_required(description="The url of the data source.")
     name: str = default_field_required(description="The name of the data source.")
-    description: str = default_field_required(
+    description: Optional[str] = default_field_required(
         description="The description of the data source."
     )
     record_type: RecordTypes = default_field_required(

--- a/tests/integration/source_collector/data_sources/sync/test_sync.py
+++ b/tests/integration/source_collector/data_sources/sync/test_sync.py
@@ -16,11 +16,16 @@ def test_source_collector_sync_data_sources(
     dbc = test_data_creator_flask.db_client
     data_sources = []
     for i in range(1001):
+        if i % 2 == 0:
+            description = f"Test Data Source {i}, created by test_source_collector_sync_data_sources()"
+        else:
+            description = None
+
         data_source = DataSource(
             name=f"Test Data Source {i}",
             source_url=f"https://test.com/{i}",
             approval_status=ApprovalStatus.APPROVED.value,
-            description=f"Test Data Source {i}, created by test_source_collector_sync_data_sources()",
+            description=description,
             record_type_id=sample_record_type_id,
         )
         data_sources.append(data_source)


### PR DESCRIPTION
### Fixes

* Bug related to https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/815

### Description

* A Pydantic model was erroneously requiring non-null descriptions in the endpoint, causing an error.
* This bug has been addressed and a test added to account for it.
