### PR TITLE
Remove URL fragments from database

### DIFF
--- a/alembic/versions/2025_08_09_1939-d2fda1435aac_remove_url_fragments.py
+++ b/alembic/versions/2025_08_09_1939-d2fda1435aac_remove_url_fragments.py
@@ -1,0 +1,58 @@
+"""Remove URL fragments
+
+Revision ID: d2fda1435aac
+Revises: 86697daa220c
+Create Date: 2025-08-09 19:39:46.734733
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d2fda1435aac"
+down_revision: Union[str, None] = "86697daa220c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    _delete_duplicate_urls()
+    _remove_url_fragments()
+    _add_constraint_forbidding_fragments()
+
+
+def downgrade() -> None:
+    _drop_constraint_forbidding_fragments()
+
+
+def _delete_duplicate_urls():
+    op.execute(
+        """
+        DELETE FROM data_sources WHERE id in (1642, 1074, 1140, 2925, 1547, 1059)
+        """
+    )
+
+
+def _remove_url_fragments():
+    op.execute("""
+    UPDATE data_sources
+    SET source_url = split_part(source_url, '#', 1)
+    WHERE position('#' in source_url) > 0;
+    """)
+
+
+def _add_constraint_forbidding_fragments() -> None:
+    op.execute("""
+    ALTER TABLE data_sources
+    ADD CONSTRAINT data_sources_source_url_fragment_check CHECK (position('#' in source_url) = 0);
+    """)
+
+
+def _drop_constraint_forbidding_fragments() -> None:
+    op.execute("""
+    ALTER TABLE data_sources
+    DROP CONSTRAINT data_sources_source_url_fragment_check;
+    """)


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/843

### Description

*  Remove URLs that are duplicated by virtue of some having fragments (or multiple having different fragments)
* Remove fragments from URLs
* Set up constraint forbidding URLs from having fragments.

### Testing

* Run tests and confirm functionality
* Run migration on local version of database and confirm runs without error.

### Performance

* Impact marginal

### Docs

* No documentation changes

### Breaking Changes

* Attempting to add URLs with fragments at the database level will throw an error.