### PR TITLE
Finish deprecating endpoints

### DIFF
--- a/endpoints/instantiations/locations_/locations.py
+++ b/endpoints/instantiations/locations_/locations.py
@@ -76,6 +76,7 @@ class LocationsByID(PsycopgResource):
         ),
     )
     @limiter.limit("60/minute")
+    @namespace_locations.deprecated
     def put(self, location_id: int, access_info: AccessInfoPrimary) -> Response:
         return self.run_endpoint(
             wrapper_function=update_location_by_id_wrapper,


### PR DESCRIPTION
### Fixes

* Addresses DS side of https://github.com/Police-Data-Accessibility-Project/data-source-manager/issues/423

### Description

* Deprecates various endpoints and eliminates their tests:
   - `/agencies` `POST`
   - `/agencies/{resource_id}` `PUT`
   - `/agencies/{resource_id}` `DELETE`
   - `/agencies/{resouce_id}/locations/{location_id}` `POST`
   - `/agencies/{resouce_id}/locations/{location_id}` `DELETE`
   - `/locations/{location_id}` `PUT`

### Testing

* Run tests and confirm all pass as expected

### Performance

* Decrease in test overhead 

### Docs

* Above endpoints now marked as deprecated

### Breaking Changes

* No breaking changes, but support for above endpoints is ending, and endpoints will eventually be removed. 