### PR TITLE
Fix bug in get user by ID

### DIFF
--- a/endpoints/instantiations/user/_shared/dtos/recent_searches.py
+++ b/endpoints/instantiations/user/_shared/dtos/recent_searches.py
@@ -7,7 +7,7 @@ from utilities.enums import RecordCategoryEnum
 
 
 class GetUserRecentSearchesDTO(BaseModel):
-    state_name: str = default_field_required(
+    state_name: Optional[str] = default_field_required(
         description="The state name of the recent search."
     )
     county_name: Optional[str] = default_field_required(
@@ -16,10 +16,10 @@ class GetUserRecentSearchesDTO(BaseModel):
     locality_name: Optional[str] = default_field_required(
         description="The locality name of the recent search."
     )
-    location_type: str = default_field_required(
+    location_type: Optional[str] = default_field_required(
         description="The location type of the recent search."
     )
-    location_id: int = default_field_required(
+    location_id: Optional[int] = default_field_required(
         description="The location id of the recent search."
     )
     record_categories: list[RecordCategoryEnum] = default_field_required(

--- a/endpoints/instantiations/user/by_id/get/query.py
+++ b/endpoints/instantiations/user/by_id/get/query.py
@@ -129,10 +129,10 @@ class GetUserByIdQueryBuilder(QueryBuilderBase):
     ) -> GetUserRecentSearchesOuterDTO:
         results: list[GetUserRecentSearchesDTO] = []
         for recent_search in recent_searches:
-            location: Location = recent_search.location
-            state: USState = location.state
-            county: County = location.county
-            locality: Locality = location.locality
+            location: Location | None = recent_search.location
+            state: USState | None = location.state if location else None
+            county: County | None = location.county if location else None
+            locality: Locality | None = location.locality if location else None
 
             record_categories: list[RecordCategory] = recent_search.record_categories
             rc_enums: list[RecordCategoryEnum] = []
@@ -140,11 +140,11 @@ class GetUserByIdQueryBuilder(QueryBuilderBase):
                 rc_enums.append(RecordCategoryEnum(record_category.name))
 
             dto = GetUserRecentSearchesDTO(
-                location_id=location.id,
+                location_id=location.id if location else None,
                 state_name=state.state_name if state else None,
                 county_name=county.name if county else None,
                 locality_name=locality.name if locality else None,
-                location_type=location.type,
+                location_type=location.type if location else None,
                 record_categories=rc_enums,
             )
             results.append(dto)

--- a/tests/helpers/helper_classes/RequestValidator.py
+++ b/tests/helpers/helper_classes/RequestValidator.py
@@ -348,7 +348,7 @@ class RequestValidator:
     def search(
         self,
         headers: dict,
-        location_id: int,
+        location_id: int | None = None,
         record_categories: list[RecordCategoryEnum] | None = None,
         record_types: list[RecordTypesEnum] | None = None,
         format: OutputFormatEnum | None = OutputFormatEnum.JSON,

--- a/tests/integration/user/profile/test_get_by_id.py
+++ b/tests/integration/user/profile/test_get_by_id.py
@@ -1,6 +1,6 @@
 from http import HTTPStatus
 
-from middleware.enums import PermissionsEnum
+from middleware.enums import PermissionsEnum, RecordTypesEnum
 from middleware.schema_and_dto.schemas.common.common_response_schemas import (
     MessageSchema,
 )
@@ -21,6 +21,12 @@ def test_user_profile_get_by_id(
     tdc.request_validator.search(
         headers=tus.api_authorization_header,
         location_id=pennsylvania_id,
+    )
+
+    # Create another recent search with no location
+    tdc.request_validator.search(
+        headers=tus.api_authorization_header,
+        record_types=[RecordTypesEnum.BOOKING_REPORTS],
     )
 
     # Have the user follow a search


### PR DESCRIPTION
### Fixes

* Bug observed by @joshuagraber 

### Description

* @joshuagraber  observed a bug where calling `/user/{id}` `GET` was triggering an error
* On investigating, this turned out to be the result of the user having performed searches that did not have locations, which were not accounting for in the logic retrieving recent searches for that user.
* This has now been adjusted.

### Testing

* Run tests and confirm functionality 
 
### Performance

* Impact marginal

### Docs

* `/user/{id}` `GET` documentation updated -- recent searches now permit optional state names, location types, and location ids.

### Breaking Changes

* No breaking changes.