### PR TITLE
Fix bug with duplicate record categories appearing

### DIFF
--- a/endpoints/v3/user/by_id/get/queries/core.py
+++ b/endpoints/v3/user/by_id/get/queries/core.py
@@ -192,12 +192,12 @@ class GetUserByIdQueryBuilder(QueryBuilderBase):
             # Compile Record Types and Categories
             subscriptions_by_category: dict[str, str] = {}
             record_types: list[RecordTypesEnum] = []
-            record_categories: list[RecordCategoryEnum] = []
+            record_categories: set[RecordCategoryEnum] = set()
             for record_type in follow.record_types:
                 record_category_name = record_type.record_category.name
                 record_type_name = record_type.name
                 record_types.append(RecordTypesEnum(record_type_name))
-                record_categories.append(RecordCategoryEnum(record_category_name))
+                record_categories.add(RecordCategoryEnum(record_category_name))
                 subscriptions_by_category[record_category_name] = record_type_name
 
             result = GetUserFollowedSearchModel(
@@ -216,7 +216,7 @@ class GetUserByIdQueryBuilder(QueryBuilderBase):
                 ),
                 record_types_by_category=subscriptions_by_category,
                 record_types=record_types,
-                record_categories=record_categories,
+                record_categories=list(record_categories),
             )
             results.append(result)
 

--- a/tests/integration/v3/user/by_id/get/test_national_follow.py
+++ b/tests/integration/v3/user/by_id/get/test_national_follow.py
@@ -1,0 +1,30 @@
+from endpoints.v3.user.by_id.get.response.core import GetUserProfileResponse
+from tests.helpers.helper_classes.test_data_creator.db_client_.core import TestDataCreatorDBClient
+from tests.helpers.test_dataclasses import TestUserDBInfo
+from tests.integration.v3.helpers.api_test_helper import APITestHelper
+
+
+def test_national_follow(
+    test_data_creator_db_client: TestDataCreatorDBClient,
+    api_test_helper: APITestHelper,
+    national_id: int,
+    monkeypatch
+):
+    tdc = test_data_creator_db_client
+    tus: TestUserDBInfo = tdc.user()
+
+    # Add national search follow
+    test_data_creator_db_client.db_client.create_followed_search(
+        user_id=tus.id,
+        location_id=national_id,
+    )
+
+    # Call user profile endpoint and confirm it returns results
+    monkeypatch.setattr(
+        "endpoints.v3.user.by_id.get.wrapper._check_user_is_either_owner_or_admin",
+        lambda x, user_id: None,
+    )
+    json: dict = api_test_helper.request_validator.get_v3(f"/user/{tus.id}")
+    model = GetUserProfileResponse(**json)
+
+    assert len(model.followed_searches[0].record_categories) == 6


### PR DESCRIPTION
### Fixes

* https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/900

### Description

* Fix bug causing duplicate record categories to appear  in `v3/user/:id` `GET`
* Add test that checks for this in case of user following national search, which is where the bug was initially discovered

### Testing

* Run tests and confirm functionality

### Performance

* Impact marginal

### Docs

* No documentation changes 

### Breaking Changes

* No breaking changes.