### PR TITLE
Add Fuzzy Match to agencies typeahead

### DIFF
--- a/db/client/core.py
+++ b/db/client/core.py
@@ -494,6 +494,16 @@ class DatabaseClient:
             search_term
         )
         self.cursor.execute(query)
+        results = self.cursor.fetchall()
+        if len(results) > 0:
+            return results
+
+        fuzzy_match_query = (
+            DynamicQueryConstructor.generate_fuzzy_match_typeahead_agencies_query(
+                search_term
+            )
+        )
+        self.cursor.execute(fuzzy_match_query)
         return self.cursor.fetchall()
 
     @cursor_manager()

--- a/db/dynamic_query_constructor.py
+++ b/db/dynamic_query_constructor.py
@@ -112,6 +112,24 @@ class DynamicQueryConstructor:
         return query
 
     @staticmethod
+    def generate_fuzzy_match_typeahead_agencies_query(search_term: str) -> sql.Composed:
+        query = sql.SQL(
+            """
+            SELECT 
+                id,
+                name as display_name,
+                jurisdiction_type,
+                state_iso,
+                municipality as locality_name,
+                county_name
+            FROM typeahead_agencies
+            ORDER BY similarity(name, {search_term}) DESC
+            LIMIT 10
+            """
+        ).format(search_term=sql.Literal(search_term))
+        return query
+
+    @staticmethod
     def generate_like_typeahead_locations_query(search_term: str) -> sql.Composed:
         query = sql.SQL(
             """

--- a/tests/integration/test_typeahead_suggestions.py
+++ b/tests/integration/test_typeahead_suggestions.py
@@ -126,3 +126,12 @@ def test_typeahead_agencies_approved(test_data_creator_flask: TestDataCreatorFla
 
     assert "Qzy" in result["display_name"]
     assert result["id"] == int(agency_id)
+
+    # Even the most absurd misspellings should pull back something
+    json_content = run_and_validate_request(
+        flask_client=tdc.flask_client,
+        http_method="get",
+        endpoint="/typeahead/locations?query=AbsolutelyGodawfulMisspelledEntryThatShouldMatchNothing",
+        expected_schema=TypeaheadLocationsOuterResponseSchema,
+    )
+    assert len(json_content["suggestions"]) >= 1


### PR DESCRIPTION
### Fixes

* #708 

### Description

* Add fuzzy matching component to typeahead to ensure results always returned

### Testing

* Run tests and confirm run as expected

### Performance

* Impact marginal

### Docs

* No documentation changes

### Breaking Changes

* No breaking changes