### PR TITLE
fix: return 401 instead of 500 on malformed GitHub OAuth tokens (#951)

### DIFF
--- a/middleware/primary_resource_logic/github_oauth.py
+++ b/middleware/primary_resource_logic/github_oauth.py
@@ -1,7 +1,7 @@
 import uuid
 
 from flask import Response
-from jwt import ExpiredSignatureError
+from jwt import DecodeError, ExpiredSignatureError
 from pydantic import BaseModel
 from werkzeug.exceptions import Unauthorized, BadRequest
 
@@ -103,6 +103,8 @@ def get_github_user_info(access_token: str) -> GithubUserInfo:
         )
     except ExpiredSignatureError:
         raise Unauthorized("Access token has expired.")
+    except DecodeError:
+        raise Unauthorized("Invalid access token.")
     gh_access_token = simple_jwt.sub
     return GithubUserInfo(
         user_id=get_github_user_id(gh_access_token),

--- a/middleware/security/jwt/core.py
+++ b/middleware/security/jwt/core.py
@@ -1,7 +1,7 @@
 import datetime
 
 import jwt
-from jwt import InvalidSignatureError
+from jwt import DecodeError, InvalidSignatureError
 from werkzeug.exceptions import BadRequest, Unauthorized
 
 from middleware.security.jwt.constants import ALGORITHM
@@ -34,7 +34,14 @@ class SimpleJWT:
 
     @staticmethod
     def decode(token: str, expected_purpose: JWTPurpose | None = None):
-        kid = int(jwt.get_unverified_header(token)["kid"])
+        try:
+            kid = int(jwt.get_unverified_header(token)["kid"])
+        except (KeyError, TypeError, ValueError) as err:
+            # Missing/non-int "kid" header — treat as a malformed token so
+            # callers only need to handle DecodeError (PyJWT already raises
+            # DecodeError for segment-level malformedness; this covers the
+            # remaining header-shape cases).
+            raise DecodeError("Invalid token.") from err
         decoded_purpose = JWTPurpose(kid)
         if expected_purpose is not None:
             SimpleJWT.validate_purpose(decoded_purpose, expected_purpose)

--- a/tests/integration/oauth/test_github_token_malformed.py
+++ b/tests/integration/oauth/test_github_token_malformed.py
@@ -1,0 +1,66 @@
+from http import HTTPStatus
+
+import pytest
+
+from middleware.schema_and_dto.schemas.common.common_response_schemas import (
+    MessageSchema,
+)
+from tests.helpers.constants import (
+    GITHUB_OAUTH_LINK_ENDPOINT,
+    GITHUB_OAUTH_LOGIN_ENDPOINT,
+)
+from tests.helpers.helper_classes.test_data_creator.flask import (
+    TestDataCreatorFlask,
+)
+from tests.helpers.run_and_validate_request import run_and_validate_request
+
+
+@pytest.mark.parametrize(
+    "malformed_token",
+    [
+        "not-a-jwt",  # no dots at all → PyJWT raises ValueError on rsplit
+        "only.two",  # only one dot → DecodeError: Not enough segments
+        "",  # empty string
+    ],
+)
+def test_github_oauth_token_malformed_login(
+    test_data_creator_flask: TestDataCreatorFlask, malformed_token: str
+):
+    """A malformed gh_access_token should return 401, not 500."""
+    tdc = test_data_creator_flask
+
+    run_and_validate_request(
+        flask_client=tdc.flask_client,
+        http_method="post",
+        endpoint=GITHUB_OAUTH_LOGIN_ENDPOINT,
+        expected_schema=MessageSchema(),
+        expected_response_status=HTTPStatus.UNAUTHORIZED,
+        json={"gh_access_token": malformed_token},
+    )
+
+
+@pytest.mark.parametrize(
+    "malformed_token",
+    [
+        "not-a-jwt",
+        "only.two",
+        "",
+    ],
+)
+def test_github_oauth_token_malformed_link(
+    test_data_creator_flask: TestDataCreatorFlask, malformed_token: str
+):
+    tdc = test_data_creator_flask
+    tus = tdc.standard_user()
+
+    run_and_validate_request(
+        flask_client=tdc.flask_client,
+        http_method="post",
+        endpoint=GITHUB_OAUTH_LINK_ENDPOINT,
+        expected_schema=MessageSchema(),
+        expected_response_status=HTTPStatus.UNAUTHORIZED,
+        json={
+            "user_email": tus.user_info.email,
+            "gh_access_token": malformed_token,
+        },
+    )

--- a/tests/middleware/test_simple_jwt.py
+++ b/tests/middleware/test_simple_jwt.py
@@ -1,0 +1,26 @@
+"""Unit tests for SimpleJWT.decode error handling on malformed tokens."""
+
+import pytest
+from jwt import DecodeError
+
+from middleware.security.jwt.core import SimpleJWT
+from middleware.security.jwt.enums import JWTPurpose
+
+
+@pytest.mark.parametrize(
+    "malformed_token",
+    [
+        "not-a-jwt",  # no dots → PyJWT ValueError on rsplit, wrapped to DecodeError
+        "only.two",  # 1 dot → DecodeError: Not enough segments
+        "",  # empty
+        "garbage.garbage.garbage",  # 3 segments but not a valid JWT header
+    ],
+)
+def test_decode_malformed_token_raises_decode_error(malformed_token: str):
+    """Malformed tokens must raise DecodeError — not leak a bare ValueError
+    — so callers can handle a single exception type.
+    """
+    with pytest.raises(DecodeError):
+        SimpleJWT.decode(
+            malformed_token, expected_purpose=JWTPurpose.GITHUB_ACCESS_TOKEN
+        )


### PR DESCRIPTION
## Summary
- Malformed `gh_access_token` values sent to `/oauth/login-with-github` and `/oauth/link-to-github` were raising `jwt.DecodeError` (and a leaked `ValueError: not enough values to unpack`) unhandled, producing 500s and the SolarWinds stack-trace alerts noted in #951.
- `SimpleJWT.decode` now normalizes header-shape malformedness (missing/non-int `kid`) to `DecodeError` so callers only handle one exception type.
- `get_github_user_info` now catches `DecodeError` and surfaces it as `401 Unauthorized`, matching the existing treatment of `ExpiredSignatureError`.

## Test plan
- [x] New unit tests (`tests/middleware/test_simple_jwt.py`) cover: no-dot, one-dot, empty, and 3-segment-but-invalid tokens.
- [x] New integration tests (`tests/integration/oauth/test_github_token_malformed.py`) hit both `/oauth/login-with-github` and `/oauth/link-to-github` with the same malformed inputs and assert 401.
- [x] Existing OAuth token-expired test, auth, and middleware suites still pass.
- [x] `ruff check` and `basedpyright --level error` clean.

Closes #951.

🤖 Generated with [Claude Code](https://claude.com/claude-code)