### PR TITLE
fix: deterministic ordering in get_change_logs_for_table (#953)

### DIFF
--- a/db/client/core.py
+++ b/db/client/core.py
@@ -1211,7 +1211,9 @@ class DatabaseClient:
             ChangeLog.old_data,
             ChangeLog.new_data,
             ChangeLog.created_at,
-        ).where(ChangeLog.table_name == table.value)
+        ).where(ChangeLog.table_name == table.value).order_by(
+            ChangeLog.created_at.asc(), ChangeLog.id.asc()
+        )
         return self.mappings(query)
 
     @session_manager


### PR DESCRIPTION
## Summary
- Adds `ORDER BY created_at ASC, id ASC` to `DatabaseClient.get_change_logs_for_table` so logs are returned in a deterministic order.
- Fixes the intermittent CI failure in `tests/test_database.py::test_agencies_table_logic` where the INSERT and UPDATE rows could be returned in either order when their `created_at` timestamps matched.

Closes #953.

## Test plan
- [ ] CI green on `tests/test_database.py::test_agencies_table_logic`
- [ ] Full pytest suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)