### PR TITLE
fix: paginate GitHub GraphQL queries (#675)

### DIFF
--- a/middleware/third_party_interaction_logic/github/helpers.py
+++ b/middleware/third_party_interaction_logic/github/helpers.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional
+from typing import Optional, Union
 
 import requests
 
@@ -39,59 +39,85 @@ def get_issue_project_statii_and_labels(global_ids: list[str]):
     return response
 
 
-def generate_issues_and_project_get_graphql_query():
-    return """
-    query {
-      organization(login: "Police-Data-Accessibility-Project") {
-        projectV2(number: 26) {  # Specific project number
+def generate_issues_and_project_get_graphql_query(after: Optional[str] = None) -> str:
+    """Build the GraphQL query for fetching project items.
+
+    When ``after`` is provided, the query will request the page of items
+    following the given cursor; otherwise the first page is requested.
+    """
+    after_arg = f', after: "{after}"' if after is not None else ""
+    return f"""
+    query {{
+      organization(login: "Police-Data-Accessibility-Project") {{
+        projectV2(number: 26) {{
           title
-          items(first: 100) {
-            nodes {
-              content {
-                ... on Issue {
+          items(first: 100{after_arg}) {{
+            pageInfo {{
+              endCursor
+              hasNextPage
+            }}
+            nodes {{
+              content {{
+                ... on Issue {{
                   number
                   title
-                  labels(first: 10) {   # Fetching issue labels
-                    nodes {
+                  labels(first: 10) {{
+                    nodes {{
                       name
-                    }
-                  }
-                }
-              }
-              fieldValueByName(name: "Status") {
-                ... on ProjectV2ItemFieldSingleSelectValue {
+                    }}
+                  }}
+                }}
+              }}
+              fieldValueByName(name: "Status") {{
+                ... on ProjectV2ItemFieldSingleSelectValue {{
                   name
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+                }}
+              }}
+            }}
+          }}
+        }}
+      }}
+    }}
     """
 
 
-def convert_graph_ql_result_to_issue_info(result: dict):
-    gipi = GithubIssueProjectInfo()
+def _extract_items(result: dict) -> dict:
     data = result.get("data")
     if data is None:
         raise ValueError("No data in result")
     organization = data.get("organization")
     project_v2 = organization.get("projectV2")
-    items = project_v2.get("items")
-    nodes = items.get("nodes")
-    for node in nodes:
-        issue_number = node.get("content").get("number")
-        project_status = node.get("fieldValueByName").get("name")
-        label_nodes = node.get("content").get("labels").get("nodes")
-        record_types = []
-        for label_node in label_nodes:
-            if "RT-" in label_node.get("name"):
-                record_type_name = re.sub("RT-", "", label_node.get("name"))
-                record_types.append(record_type_name)
-        gipi_info = GIPIInfo(project_status=project_status, record_types=record_types)
+    return project_v2.get("items")
 
-        gipi.add_info(issue_number=issue_number, gipi_info=gipi_info)
+
+def convert_graph_ql_result_to_issue_info(
+    result: Union[dict, list[dict]],
+) -> GithubIssueProjectInfo:
+    """Convert one or more project-items response payloads into a
+    ``GithubIssueProjectInfo`` instance.
+
+    Accepts either a single response dict (single page) or a list of response
+    dicts (paginated calls), merging all nodes into the result.
+    """
+    pages: list[dict] = result if isinstance(result, list) else [result]
+    gipi = GithubIssueProjectInfo()
+    for page in pages:
+        items = _extract_items(page)
+        nodes = items.get("nodes") or []
+        for node in nodes:
+            issue_number = node.get("content").get("number")
+            project_status = node.get("fieldValueByName").get("name")
+            label_nodes = node.get("content").get("labels").get("nodes")
+            record_types = []
+            for label_node in label_nodes:
+                if "RT-" in label_node.get("name"):
+                    record_type_name = re.sub("RT-", "", label_node.get("name"))
+                    record_types.append(record_type_name)
+            gipi_info = GIPIInfo(
+                project_status=project_status, record_types=record_types
+            )
+
+            gipi.add_info(issue_number=issue_number, gipi_info=gipi_info)
 
     return gipi
 
@@ -99,13 +125,28 @@ def convert_graph_ql_result_to_issue_info(result: dict):
 def get_github_issue_project_statuses(
     issue_numbers: list[int],
 ) -> GithubIssueProjectInfo:
-    query = generate_issues_and_project_get_graphql_query()
+    """Fetch project statuses for issues, following GraphQL cursor pagination.
 
-    response = make_graph_ql_query(query=query)
+    GitHub's GraphQL API caps ``first`` at 100, so for projects with more than
+    100 items we must follow the ``pageInfo.endCursor`` cursor until
+    ``hasNextPage`` is false. See issue #675.
+    """
+    pages: list[dict] = []
+    after: Optional[str] = None
+    while True:
+        query = generate_issues_and_project_get_graphql_query(after=after)
+        response = make_graph_ql_query(query=query)
+        pages.append(response)
 
-    gipi = convert_graph_ql_result_to_issue_info(response)
+        items = _extract_items(response)
+        page_info = items.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        after = page_info.get("endCursor")
+        if after is None:
+            break
 
-    return gipi
+    return convert_graph_ql_result_to_issue_info(pages)
 
 
 def make_graph_ql_query(query: str, variables: Optional[dict] = None):

--- a/middleware/third_party_interaction_logic/github/label_manager.py
+++ b/middleware/third_party_interaction_logic/github/label_manager.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from middleware.third_party_interaction_logic.github.constants import (
     GH_ORG_NAME,
     GH_REPO_NAME,
@@ -9,11 +11,17 @@ class GithubLabelManager:
     def __init__(self):
         self.label_name_to_id = self.get_labels()
 
-    def get_labels(self):
-        query = """
+    @staticmethod
+    def _build_labels_query(after: Optional[str] = None) -> str:
+        after_arg = f', after: "{after}"' if after is not None else ""
+        return """
         query {
           repository(owner: "%s", name: "%s") {
-            labels(first: 100) {
+            labels(first: 100%s) {
+              pageInfo {
+                endCursor
+                hasNextPage
+              }
               nodes {
                 id
                 name
@@ -24,10 +32,30 @@ class GithubLabelManager:
         """ % (
             GH_ORG_NAME,
             GH_REPO_NAME,
+            after_arg,
         )
-        response = make_graph_ql_query(query=query)
-        labels = response["data"]["repository"]["labels"]["nodes"]
-        d = {}
-        for label in labels:
-            d[label["name"]] = label["id"]
+
+    def get_labels(self) -> dict[str, str]:
+        """Fetch all repository labels, following GraphQL cursor pagination.
+
+        GitHub's GraphQL API caps ``first`` at 100, so we must follow
+        ``pageInfo.endCursor`` until ``hasNextPage`` is false to retrieve
+        every label. See issue #675.
+        """
+        d: dict[str, str] = {}
+        after: Optional[str] = None
+        while True:
+            query = self._build_labels_query(after=after)
+            response = make_graph_ql_query(query=query)
+            labels_payload = response["data"]["repository"]["labels"]
+            for label in labels_payload["nodes"]:
+                d[label["name"]] = label["id"]
+
+            page_info = labels_payload.get("pageInfo") or {}
+            if not page_info.get("hasNextPage"):
+                break
+            after = page_info.get("endCursor")
+            if after is None:
+                break
+
         return d

--- a/tests/middleware/test_github_graphql_pagination.py
+++ b/tests/middleware/test_github_graphql_pagination.py
@@ -1,0 +1,159 @@
+"""Tests for cursor-based pagination of GitHub GraphQL queries.
+
+These tests verify that paginated helpers correctly issue an initial query and
+then continue requesting additional pages while ``hasNextPage`` is true,
+threading the ``endCursor`` through as the ``after`` argument.
+
+Issue: https://github.com/Police-Data-Accessibility-Project/data-sources-app/issues/675
+"""
+
+from unittest.mock import patch
+
+from middleware.third_party_interaction_logic.github.helpers import (
+    convert_graph_ql_result_to_issue_info,
+    get_github_issue_project_statuses,
+)
+from middleware.third_party_interaction_logic.github.label_manager import (
+    GithubLabelManager,
+)
+
+
+def _make_project_items_response(
+    nodes: list[dict], end_cursor: str | None, has_next_page: bool
+) -> dict:
+    return {
+        "data": {
+            "organization": {
+                "projectV2": {
+                    "title": "Test Project",
+                    "items": {
+                        "pageInfo": {
+                            "endCursor": end_cursor,
+                            "hasNextPage": has_next_page,
+                        },
+                        "nodes": nodes,
+                    },
+                }
+            }
+        }
+    }
+
+
+def _project_node(issue_number: int, status: str = "Active") -> dict:
+    return {
+        "content": {
+            "number": issue_number,
+            "title": f"Issue {issue_number}",
+            "labels": {"nodes": []},
+        },
+        "fieldValueByName": {"name": status},
+    }
+
+
+def test_get_github_issue_project_statuses_paginates_until_no_next_page():
+    """When hasNextPage is true, the helper should issue another query
+    with the ``after`` cursor and merge the resulting nodes."""
+    page_1 = _make_project_items_response(
+        nodes=[_project_node(1), _project_node(2)],
+        end_cursor="cursor-1",
+        has_next_page=True,
+    )
+    page_2 = _make_project_items_response(
+        nodes=[_project_node(3)],
+        end_cursor="cursor-2",
+        has_next_page=False,
+    )
+
+    with patch(
+        "middleware.third_party_interaction_logic.github.helpers.make_graph_ql_query"
+    ) as mock_query:
+        mock_query.side_effect = [page_1, page_2]
+        gipi = get_github_issue_project_statuses([1, 2, 3])
+
+    assert mock_query.call_count == 2
+    # Second call should include the cursor from the first response.
+    second_call_query = mock_query.call_args_list[1].kwargs["query"]
+    assert 'after: "cursor-1"' in second_call_query
+
+    # All issues across both pages should be merged into the result.
+    assert {1, 2, 3} <= set(gipi.issue_number_to_info.keys())
+
+
+def test_get_github_issue_project_statuses_single_page_no_extra_calls():
+    """If the first page has hasNextPage=false, no further calls are made."""
+    page = _make_project_items_response(
+        nodes=[_project_node(1)],
+        end_cursor=None,
+        has_next_page=False,
+    )
+
+    with patch(
+        "middleware.third_party_interaction_logic.github.helpers.make_graph_ql_query"
+    ) as mock_query:
+        mock_query.return_value = page
+        gipi = get_github_issue_project_statuses([1])
+
+    assert mock_query.call_count == 1
+    assert 1 in gipi.issue_number_to_info
+
+
+def test_convert_graph_ql_result_to_issue_info_merges_pages():
+    """convert_graph_ql_result_to_issue_info should accept multiple page
+    payloads and merge their nodes."""
+    page_1 = _make_project_items_response(
+        nodes=[_project_node(10), _project_node(11)],
+        end_cursor="c1",
+        has_next_page=True,
+    )
+    page_2 = _make_project_items_response(
+        nodes=[_project_node(12)],
+        end_cursor="c2",
+        has_next_page=False,
+    )
+
+    gipi = convert_graph_ql_result_to_issue_info([page_1, page_2])
+    assert {10, 11, 12} <= set(gipi.issue_number_to_info.keys())
+
+
+def test_label_manager_paginates_labels():
+    """GithubLabelManager.get_labels should follow the labels pageInfo
+    cursor across multiple pages."""
+    page_1 = {
+        "data": {
+            "repository": {
+                "labels": {
+                    "pageInfo": {"endCursor": "lc-1", "hasNextPage": True},
+                    "nodes": [
+                        {"id": "id-a", "name": "label-a"},
+                        {"id": "id-b", "name": "label-b"},
+                    ],
+                }
+            }
+        }
+    }
+    page_2 = {
+        "data": {
+            "repository": {
+                "labels": {
+                    "pageInfo": {"endCursor": "lc-2", "hasNextPage": False},
+                    "nodes": [{"id": "id-c", "name": "label-c"}],
+                }
+            }
+        }
+    }
+
+    with patch(
+        "middleware.third_party_interaction_logic.github.label_manager."
+        "make_graph_ql_query"
+    ) as mock_query:
+        mock_query.side_effect = [page_1, page_2]
+        manager = GithubLabelManager()
+
+    assert mock_query.call_count == 2
+    second_call_query = mock_query.call_args_list[1].kwargs["query"]
+    assert 'after: "lc-1"' in second_call_query
+    assert manager.label_name_to_id == {
+        "label-a": "id-a",
+        "label-b": "id-b",
+        "label-c": "id-c",
+    }


### PR DESCRIPTION
## Summary

GitHub's GraphQL API caps the `first` argument at 100, so any query that may return more than 100 nodes needs cursor-based pagination via `pageInfo { endCursor hasNextPage }` and an `after:` cursor on subsequent calls.

This PR adds that pagination to the two queries where the 100-node cap is reachable in practice:

- `get_github_issue_project_statuses` in `middleware/third_party_interaction_logic/github/helpers.py` (project items grow with every data request issue).
- `GithubLabelManager.get_labels` in `middleware/third_party_interaction_logic/github/label_manager.py` (repository labels).

Other `first: N` usages have small bounded N (`labels(first: 10)` per issue, `fields(first: 20)` for project fields) and are intentionally left as-is.

`convert_graph_ql_result_to_issue_info` now accepts either a single response dict or a list of page dicts so callers can hand in all paginated responses at once.

Closes #675

## Test plan

- [x] New unit tests in `tests/middleware/test_github_graphql_pagination.py` cover:
  - Multi-page project-status fetch threads `endCursor` into the next `after:` argument and merges nodes.
  - Single-page response stops after one call.
  - `convert_graph_ql_result_to_issue_info` correctly merges multiple page payloads.
  - `GithubLabelManager` paginates label results across pages.
- [x] `uv run ruff check .` passes.
- [x] `uv run basedpyright --level error` passes (0 errors).
- [ ] Full `uv run pytest tests` should be run in CI (local DB unavailable in this environment, so only the four new unit tests were executed locally via `--noconftest`).

## Notes for reviewers

- No callers outside of these two modules use the changed helpers, so the `dict | list[dict]` union on `convert_graph_ql_result_to_issue_info` is purely forward-compatible.
- The `after:` cursor is interpolated as a string literal into the query rather than being passed as a GraphQL variable, matching the existing string-templated style in this module. Could be migrated to `$variables` later if desired.