### PR TITLE
feat: add user display_name (#875)

### DIFF
--- a/alembic/versions/c4a3f8e1d75b_add_user_display_name.py
+++ b/alembic/versions/c4a3f8e1d75b_add_user_display_name.py
@@ -1,0 +1,56 @@
+"""Add user display_name
+
+Revision ID: c4a3f8e1d75b
+Revises: 71374f18982c
+Create Date: 2026-05-02 08:45:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c4a3f8e1d75b"
+down_revision: Union[str, None] = "71374f18982c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # users.display_name -- nullable first so we can backfill existing rows
+    op.add_column(
+        "users",
+        sa.Column("display_name", sa.String(length=30), nullable=True),
+    )
+
+    # Backfill existing rows with the user id, left-padded to 3 chars so it
+    # satisfies the 3-character minimum length validator. Uniqueness is
+    # guaranteed because user.id is unique.
+    op.execute("UPDATE users SET display_name = LPAD(id::text, 3, '0')")
+
+    op.alter_column("users", "display_name", nullable=False)
+
+    # Case-insensitive uniqueness via a functional unique index on LOWER().
+    op.create_index(
+        "uq_users_display_name_lower",
+        "users",
+        [sa.text("LOWER(display_name)")],
+        unique=True,
+    )
+
+    # pending_users.display_name -- optional field captured at signup so the
+    # display name can be carried over to the user row at email validation.
+    op.add_column(
+        "pending_users",
+        sa.Column("display_name", sa.String(length=30), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("pending_users", "display_name")
+    op.drop_index("uq_users_display_name_lower", table_name="users")
+    op.drop_column("users", "display_name")

--- a/db/client/core.py
+++ b/db/client/core.py
@@ -305,10 +305,14 @@ class DatabaseClient:
         email: str,
         password_digest: str,
         capacities: list[UserCapacityEnum] | None = None,
+        display_name: str | None = None,
     ) -> int | None:
         """Adds a new user to the database."""
         builder = CreateNewUserQueryBuilder(
-            email=email, password_digest=password_digest, capacities=capacities
+            email=email,
+            password_digest=password_digest,
+            capacities=capacities,
+            display_name=display_name,
         )
         return self.run_query_builder(builder)
 
@@ -1264,6 +1268,7 @@ class DatabaseClient:
         password_digest: str,
         validation_token: str,
         capacities: list[UserCapacityEnum] | None,
+        display_name: str | None = None,
     ):
         self.add(
             PendingUser(
@@ -1273,8 +1278,17 @@ class DatabaseClient:
                 capacities=[capacity.value for capacity in capacities]
                 if capacities
                 else [],
+                display_name=display_name,
             )
         )
+
+    def display_name_taken(self, display_name: str) -> bool:
+        """Return True if any user already has a display_name matching the
+        given value (case-insensitive)."""
+        query = select(User.id).where(
+            func.lower(User.display_name) == display_name.lower()
+        )
+        return self.scalar(query) is not None
 
     def delete_user(self, user_id: int):
         query = delete(User).where(User.id == user_id)

--- a/db/models/implementations/core/user/core.py
+++ b/db/models/implementations/core/user/core.py
@@ -21,6 +21,7 @@ class User(StandardBase, CreatedAtMixin):
         server_default=text_func("generate_api_key()")
     )
     role: Mapped[text | None]
+    display_name: Mapped[str] = mapped_column(unique=False)
 
     # Relationships
     permissions = relationship(

--- a/db/models/implementations/core/user/pending.py
+++ b/db/models/implementations/core/user/pending.py
@@ -14,6 +14,7 @@ class PendingUser(StandardBase, CreatedAtMixin):
     email: Mapped[str] = mapped_column(unique=True)
     password_digest: Mapped[str | None]
     validation_token: Mapped[str | None]
+    display_name: Mapped[str | None]
     capacities: Mapped[list[UserCapacityEnum]] = enum_list_column(
         enum=UserCapacityEnum,
         name="user_capacities_enum",

--- a/db/queries/instantiations/user/create.py
+++ b/db/queries/instantiations/user/create.py
@@ -1,4 +1,5 @@
 from typing import final, override
+from uuid import uuid4
 
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
@@ -34,8 +35,14 @@ class CreateNewUserQueryBuilder(QueryBuilderBase):
             self._raise_if_display_name_taken(self.display_name)
 
         # We need the user.id before we can fall back to the id-based default
-        # display name, so insert a placeholder, flush, then update.
-        placeholder_display_name = self.display_name or "__pending__"
+        # display name, so insert a per-row unique placeholder, flush, then
+        # update. The placeholder must be unique-per-insert because the
+        # functional unique index on LOWER(display_name) would otherwise
+        # collide between concurrent signups that both omit display_name.
+        # Column is VARCHAR(30); keep prefix + truncated uuid <= 30 chars.
+        placeholder_display_name = (
+            self.display_name or f"_p_{uuid4().hex[:26]}"
+        )
         user = User(
             email=self.email,
             password_digest=self.password_digest,

--- a/db/queries/instantiations/user/create.py
+++ b/db/queries/instantiations/user/create.py
@@ -1,12 +1,16 @@
 from typing import final, override
 
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 
 from db.enums import UserCapacityEnum
 from db.models.implementations.core.user.capacity import UserCapacity
 from db.models.implementations.core.user.core import User
 from db.queries.builder.core import QueryBuilderBase
-from middleware.exceptions import DuplicateUserError
+from middleware.exceptions import DuplicateDisplayNameError, DuplicateUserError
+from middleware.schema_and_dto.dtos.user.display_name import (
+    default_display_name_for_user_id,
+)
 
 
 @final
@@ -16,22 +20,51 @@ class CreateNewUserQueryBuilder(QueryBuilderBase):
         email: str,
         password_digest: str,
         capacities: list[UserCapacityEnum] | None = None,
+        display_name: str | None = None,
     ):
         super().__init__()
         self.email = email
         self.password_digest = password_digest
         self.capacities = capacities if capacities else []
+        self.display_name = display_name
 
     @override
     def run(self) -> int:
-        user = User(email=self.email, password_digest=self.password_digest)
+        if self.display_name is not None:
+            self._raise_if_display_name_taken(self.display_name)
+
+        # We need the user.id before we can fall back to the id-based default
+        # display name, so insert a placeholder, flush, then update.
+        placeholder_display_name = self.display_name or "__pending__"
+        user = User(
+            email=self.email,
+            password_digest=self.password_digest,
+            display_name=placeholder_display_name,
+        )
         self.session.add(user)
         try:
             self.session.flush()
         except IntegrityError:
             raise DuplicateUserError
+
+        if self.display_name is None:
+            user.display_name = default_display_name_for_user_id(user.id)
+            try:
+                self.session.flush()
+            except IntegrityError:
+                raise DuplicateDisplayNameError
+
         self._add_user_capacities(user_id=user.id)
         return user.id
+
+    def _raise_if_display_name_taken(self, display_name: str) -> None:
+        existing = self.session.execute(
+            select(User.id).where(
+                func.lower(User.display_name) == display_name.lower()
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            raise DuplicateDisplayNameError
 
     def _add_user_capacities(self, user_id: int):
         for capacity in self.capacities:

--- a/endpoints/instantiations/auth_/signup/dto.py
+++ b/endpoints/instantiations/auth_/signup/dto.py
@@ -1,12 +1,13 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from db.enums import UserCapacityEnum
 from middleware.schema_and_dto.dtos._helpers import (
     default_field_required,
     default_field_not_required,
 )
+from middleware.schema_and_dto.dtos.user.display_name import validate_display_name
 
 
 class UserStandardSignupRequestDTO(BaseModel):
@@ -15,3 +16,17 @@ class UserStandardSignupRequestDTO(BaseModel):
     capacities: Optional[list[UserCapacityEnum]] = default_field_not_required(
         description="The capacities of the user"
     )
+    display_name: Optional[str] = default_field_not_required(
+        description=(
+            "Public display name. Letters, numbers, hyphens, and underscores; "
+            "3-30 characters; unique (case-insensitive). Defaults to the "
+            "user's numeric id if omitted."
+        )
+    )
+
+    @field_validator("display_name")
+    @classmethod
+    def _validate_display_name(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        return validate_display_name(value)

--- a/endpoints/instantiations/auth_/signup/middleware.py
+++ b/endpoints/instantiations/auth_/signup/middleware.py
@@ -7,6 +7,9 @@ from db.client.core import DatabaseClient
 from endpoints.instantiations.auth_.signup.dto import UserStandardSignupRequestDTO
 from middleware.common_response_formatting import message_response
 from middleware.primary_resource_logic.api_key import generate_token
+from middleware.schema_and_dto.dtos.user.display_name import (
+    DISPLAY_NAME_DUPLICATE_MESSAGE,
+)
 from middleware.security.jwt.core import SimpleJWT
 from middleware.security.jwt.enums import JWTPurpose
 from middleware.third_party_interaction_logic.mailgun_.send import send_via_mailgun
@@ -26,6 +29,11 @@ def signup_wrapper(
             "User with email has already signed up. "
             + "Please validate your email or request a new validation email."
         )
+
+    if dto.display_name is not None and db_client.display_name_taken(
+        dto.display_name
+    ):
+        raise Conflict(DISPLAY_NAME_DUPLICATE_MESSAGE)
 
     jwt_token = _setup_pending_user(db_client, dto)
 
@@ -113,6 +121,7 @@ def _setup_pending_user(
         password_digest=password_digest,
         validation_token=token,
         capacities=dto.capacities,
+        display_name=dto.display_name,
     )
     jwt_token = get_validation_token_jwt(dto.email, token)
     return jwt_token

--- a/endpoints/instantiations/auth_/validate_email/query.py
+++ b/endpoints/instantiations/auth_/validate_email/query.py
@@ -1,14 +1,18 @@
 from typing import final, override
 
-from sqlalchemy import select, delete
+from sqlalchemy import func, select, delete
 from sqlalchemy.exc import IntegrityError
-from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest, Conflict
 
 from db.models.implementations.core.user.capacity import UserCapacity
 from db.models.implementations.core.user.core import User
 from db.models.implementations.core.user.pending import PendingUser
 from db.queries.builder.core import QueryBuilderBase
-from middleware.exceptions import DuplicateUserError
+from middleware.exceptions import DuplicateDisplayNameError, DuplicateUserError
+from middleware.schema_and_dto.dtos.user.display_name import (
+    DISPLAY_NAME_DUPLICATE_MESSAGE,
+    default_display_name_for_user_id,
+)
 
 
 @final
@@ -23,9 +27,20 @@ class ValidateEmailQueryBuilder(QueryBuilderBase):
 
     def get_pending_user(self) -> PendingUser | None:
         query = select(
-            PendingUser.email, PendingUser.password_digest, PendingUser.capacities
+            PendingUser.email,
+            PendingUser.password_digest,
+            PendingUser.capacities,
+            PendingUser.display_name,
         ).where(PendingUser.validation_token == self.validation_token)
         return self.session.execute(query).one_or_none()
+
+    def _is_display_name_taken(self, display_name: str) -> bool:
+        existing = self.session.execute(
+            select(User.id).where(
+                func.lower(User.display_name) == display_name.lower()
+            )
+        ).scalar_one_or_none()
+        return existing is not None
 
     def _delete_pending_user(self):
         query = delete(PendingUser).where(
@@ -34,14 +49,33 @@ class ValidateEmailQueryBuilder(QueryBuilderBase):
         self.session.execute(query)
 
     def _create_new_user(self, pending_user: PendingUser) -> None:
+        requested_display_name: str | None = pending_user.display_name
+        if requested_display_name is not None and self._is_display_name_taken(
+            requested_display_name
+        ):
+            raise DuplicateDisplayNameError
+
+        # Insert with a placeholder display_name so we can later substitute
+        # the user id if no name was provided at signup.
+        placeholder_display_name = requested_display_name or "__pending__"
         user = User(
-            email=pending_user.email, password_digest=pending_user.password_digest
+            email=pending_user.email,
+            password_digest=pending_user.password_digest,
+            display_name=placeholder_display_name,
         )
         self.session.add(user)
         try:
             self.session.flush()
         except IntegrityError:
             raise DuplicateUserError
+
+        if requested_display_name is None:
+            user.display_name = default_display_name_for_user_id(user.id)
+            try:
+                self.session.flush()
+            except IntegrityError:
+                raise DuplicateDisplayNameError
+
         self._add_user_capacities(capacities=pending_user.capacities, user_id=user.id)
         self._delete_pending_user()
 
@@ -51,5 +85,8 @@ class ValidateEmailQueryBuilder(QueryBuilderBase):
         if pending_user is None:
             raise BadRequest("Invalid validation token.")
 
-        self._create_new_user(pending_user)
+        try:
+            self._create_new_user(pending_user)
+        except DuplicateDisplayNameError:
+            raise Conflict(DISPLAY_NAME_DUPLICATE_MESSAGE)
         return pending_user.email

--- a/endpoints/instantiations/user/by_id/get/dto.py
+++ b/endpoints/instantiations/user/by_id/get/dto.py
@@ -24,6 +24,9 @@ class ExternalAccountDTO(BaseModel):
 
 class UserProfileResponseSchemaInnerDTO(BaseModel):
     email: str = default_field_required(description="The email of the user")
+    display_name: str = default_field_required(
+        description="The public display name of the user"
+    )
     external_accounts: ExternalAccountDTO = default_field_required(
         description="The external accounts of the user"
     )

--- a/endpoints/instantiations/user/by_id/get/query.py
+++ b/endpoints/instantiations/user/by_id/get/query.py
@@ -104,6 +104,7 @@ class GetUserByIdQueryBuilder(QueryBuilderBase):
         user = self.session.execute(query).scalars().one()
         return UserProfileResponseSchemaInnerDTO(
             email=user.email,
+            display_name=user.display_name,
             external_accounts=self._process_external_accounts(user.external_accounts),
             recent_searches=self._process_recent_searches(user.recent_searches),
             followed_searches=self._process_follows(user.follows),

--- a/endpoints/instantiations/user/by_id/patch/dto.py
+++ b/endpoints/instantiations/user/by_id/patch/dto.py
@@ -1,10 +1,28 @@
-from pydantic import BaseModel
+from typing import Optional
+
+from pydantic import BaseModel, field_validator
 
 from db.enums import UserCapacityEnum
-from middleware.schema_and_dto.dtos._helpers import default_field_required
+from middleware.schema_and_dto.dtos._helpers import (
+    default_field_not_required,
+)
+from middleware.schema_and_dto.dtos.user.display_name import validate_display_name
 
 
 class UserPatchDTO(BaseModel):
-    capacities: list[UserCapacityEnum] = default_field_required(
-        description="The capacities of the user",
+    capacities: Optional[list[UserCapacityEnum]] = default_field_not_required(
+        description="The capacities of the user. Optional.",
     )
+    display_name: Optional[str] = default_field_not_required(
+        description=(
+            "Public display name. Letters, numbers, hyphens, and underscores; "
+            "3-30 characters; unique (case-insensitive)."
+        ),
+    )
+
+    @field_validator("display_name")
+    @classmethod
+    def _validate_display_name(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        return validate_display_name(value)

--- a/endpoints/instantiations/user/by_id/patch/middleware.py
+++ b/endpoints/instantiations/user/by_id/patch/middleware.py
@@ -1,10 +1,14 @@
 from flask import Response
-from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest, Conflict
 
 from db.client.core import DatabaseClient
 from endpoints.instantiations.user.by_id.patch.dto import UserPatchDTO
 from middleware.common_response_formatting import message_response
 from middleware.enums import PermissionsEnum
+from middleware.exceptions import DuplicateDisplayNameError
+from middleware.schema_and_dto.dtos.user.display_name import (
+    DISPLAY_NAME_DUPLICATE_MESSAGE,
+)
 from middleware.security.access_info.primary import AccessInfoPrimary
 
 
@@ -24,5 +28,8 @@ def patch_user(
 ) -> Response:
     if not _is_admin_or_owner(access_info, user_id):
         raise BadRequest("You do not have permission to patch this user.")
-    db_client.patch_user(user_id, dto)
+    try:
+        db_client.patch_user(user_id, dto)
+    except DuplicateDisplayNameError:
+        raise Conflict(DISPLAY_NAME_DUPLICATE_MESSAGE)
     return message_response("User patched.")

--- a/endpoints/instantiations/user/by_id/patch/query.py
+++ b/endpoints/instantiations/user/by_id/patch/query.py
@@ -1,10 +1,13 @@
 from typing import override, final
 
-from sqlalchemy import delete
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.exc import IntegrityError
 
 from db.models.implementations.core.user.capacity import UserCapacity
+from db.models.implementations.core.user.core import User
 from db.queries.builder.core import QueryBuilderBase
 from endpoints.instantiations.user.by_id.patch.dto import UserPatchDTO
+from middleware.exceptions import DuplicateDisplayNameError
 
 
 @final
@@ -16,11 +19,14 @@ class UserPatchQueryBuilder(QueryBuilderBase):
 
     @override
     def run(self) -> None:
-        self._delete_existing_user_capacities()
-        self._add_user_capacities()
+        if self.dto.capacities is not None:
+            self._delete_existing_user_capacities()
+            self._add_user_capacities()
+        if self.dto.display_name is not None:
+            self._update_display_name(self.dto.display_name)
 
     def _add_user_capacities(self):
-        for capacity in self.dto.capacities:
+        for capacity in self.dto.capacities or []:
             self.session.add(
                 UserCapacity(user_id=self.user_id, capacity=capacity.value)
             )
@@ -28,3 +34,25 @@ class UserPatchQueryBuilder(QueryBuilderBase):
     def _delete_existing_user_capacities(self):
         query = delete(UserCapacity).where(UserCapacity.user_id == self.user_id)
         _ = self.session.execute(query)
+
+    def _update_display_name(self, display_name: str) -> None:
+        # Pre-check uniqueness against other users so we can produce a
+        # descriptive error before triggering an integrity violation.
+        existing = self.session.execute(
+            select(User.id).where(
+                func.lower(User.display_name) == display_name.lower(),
+                User.id != self.user_id,
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            raise DuplicateDisplayNameError
+
+        try:
+            self.session.execute(
+                update(User)
+                .where(User.id == self.user_id)
+                .values(display_name=display_name)
+            )
+            self.session.flush()
+        except IntegrityError:
+            raise DuplicateDisplayNameError

--- a/endpoints/v3/user/by_id/get/queries/core.py
+++ b/endpoints/v3/user/by_id/get/queries/core.py
@@ -110,6 +110,7 @@ class GetUserByIdQueryBuilder(QueryBuilderBase):
         user = self.session.execute(query).scalars().one()
         return GetUserProfileResponse(
             email=user.email,
+            display_name=user.display_name,
             external_accounts=self._process_external_accounts(user.external_accounts),
             recent_searches=self._process_recent_searches(user.recent_searches),
             followed_searches=self._process_follows(user.follows),

--- a/endpoints/v3/user/by_id/get/response/core.py
+++ b/endpoints/v3/user/by_id/get/response/core.py
@@ -15,6 +15,9 @@ class GetUserProfileResponse(BaseModel):
     email: str = Field(
         description="The email of the user.",
     )
+    display_name: str = Field(
+        description="The public display name of the user.",
+    )
     external_accounts: ExternalAccountsModel = Field(
         description="The external accounts of the user.",
     )

--- a/middleware/exceptions.py
+++ b/middleware/exceptions.py
@@ -15,6 +15,12 @@ class DuplicateUserError(Exception):
     pass
 
 
+class DuplicateDisplayNameError(Exception):
+    """Raised when a requested user display_name is already in use."""
+
+    pass
+
+
 class InvalidAPIKeyException(Exception):
     pass
 

--- a/middleware/primary_resource_logic/user_queries.py
+++ b/middleware/primary_resource_logic/user_queries.py
@@ -6,7 +6,14 @@ from werkzeug.security import generate_password_hash
 
 from db.client.core import DatabaseClient
 from middleware.common_response_formatting import message_response
-from middleware.exceptions import UserNotFoundError, DuplicateUserError
+from middleware.exceptions import (
+    DuplicateDisplayNameError,
+    DuplicateUserError,
+    UserNotFoundError,
+)
+from middleware.schema_and_dto.dtos.user.display_name import (
+    DISPLAY_NAME_DUPLICATE_MESSAGE,
+)
 from utilities.enums import SourceMappingEnum
 
 
@@ -61,5 +68,7 @@ def user_post_results(db_client: DatabaseClient, dto: UserRequestDTO) -> Respons
         raise Conflict(
             f"User with email {dto.email} already exists.",
         )
+    except DuplicateDisplayNameError:
+        raise Conflict(DISPLAY_NAME_DUPLICATE_MESSAGE)
 
     return message_response("Successfully added user.")

--- a/middleware/schema_and_dto/dtos/user/display_name.py
+++ b/middleware/schema_and_dto/dtos/user/display_name.py
@@ -1,0 +1,53 @@
+"""
+Shared validator and field constants for the user `display_name` property.
+
+A user's display name is a public, case-insensitive-unique handle composed of
+letters, numbers, hyphens, and underscores. See issue #875 for context.
+"""
+
+import re
+
+DISPLAY_NAME_MIN_LENGTH = 3
+DISPLAY_NAME_MAX_LENGTH = 30
+DISPLAY_NAME_PATTERN = r"^[A-Za-z0-9_-]+$"
+_DISPLAY_NAME_REGEX = re.compile(DISPLAY_NAME_PATTERN)
+
+DISPLAY_NAME_LENGTH_MESSAGE = (
+    f"display_name must be between {DISPLAY_NAME_MIN_LENGTH} "
+    f"and {DISPLAY_NAME_MAX_LENGTH} characters."
+)
+DISPLAY_NAME_CHARSET_MESSAGE = (
+    "display_name may only contain letters, numbers, hyphens, and underscores "
+    "(no spaces or other punctuation)."
+)
+DISPLAY_NAME_DUPLICATE_MESSAGE = (
+    "display_name is already taken (matches are case-insensitive)."
+)
+
+
+def validate_display_name(value: str) -> str:
+    """Validate display_name length and character set, returning the value.
+
+    Raises ``ValueError`` so it can be used inside Pydantic field validators —
+    Pydantic wraps ``ValueError`` into a ``ValidationError`` with the message
+    intact.
+    """
+    if not isinstance(value, str):
+        raise ValueError(DISPLAY_NAME_CHARSET_MESSAGE)
+    if (
+        len(value) < DISPLAY_NAME_MIN_LENGTH
+        or len(value) > DISPLAY_NAME_MAX_LENGTH
+    ):
+        raise ValueError(DISPLAY_NAME_LENGTH_MESSAGE)
+    if not _DISPLAY_NAME_REGEX.fullmatch(value):
+        raise ValueError(DISPLAY_NAME_CHARSET_MESSAGE)
+    return value
+
+
+def default_display_name_for_user_id(user_id: int) -> str:
+    """Return the default display_name to assign when none is provided.
+
+    Defaults to the numeric user id as a string, left-padded with zeros to
+    satisfy the minimum length validator (e.g. user 7 -> "007").
+    """
+    return str(user_id).rjust(DISPLAY_NAME_MIN_LENGTH, "0")

--- a/middleware/schema_and_dto/dynamic/schema/request_content_population_/helpers.py
+++ b/middleware/schema_and_dto/dynamic/schema/request_content_population_/helpers.py
@@ -48,6 +48,13 @@ def setup_dto_class(
         if errors:
             first_error = errors[0]
             error_message = first_error.get("msg", str(e))
+            # Pydantic prefixes messages from raised ``ValueError`` with
+            # ``"Value error, "`` — strip it so our user-facing messages stay
+            # clean.
+            if isinstance(error_message, str) and error_message.startswith(
+                "Value error, "
+            ):
+                error_message = error_message[len("Value error, "):]
             raise BadRequest(error_message)
         raise BadRequest(str(e))
 

--- a/tests/integration/user/display_name/test_display_name.py
+++ b/tests/integration/user/display_name/test_display_name.py
@@ -1,0 +1,231 @@
+"""Integration tests for the user `display_name` property (issue #875)."""
+
+import uuid
+from http import HTTPStatus
+
+import pytest
+
+from db.models.implementations.core.user.core import User
+from middleware.schema_and_dto.dtos.user.display_name import (
+    DISPLAY_NAME_CHARSET_MESSAGE,
+    DISPLAY_NAME_DUPLICATE_MESSAGE,
+    DISPLAY_NAME_LENGTH_MESSAGE,
+    default_display_name_for_user_id,
+)
+from tests.integration.auth.signup.helpers import SignupTestHelper
+
+
+def _unique_display_name(prefix: str = "dn") -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def helper(test_data_creator_flask, mocker):
+    return SignupTestHelper(test_data_creator_flask, mocker)
+
+
+def _signup_with_display_name(
+    helper: SignupTestHelper, display_name: str | None
+) -> str:
+    """Run the signup + validate-email flow and return the email used."""
+    mock = helper.patch(
+        "endpoints.instantiations.auth_.signup.middleware.send_signup_link"
+    )
+    helper.tdc.request_validator.post(
+        endpoint="/auth/signup",
+        json={
+            "email": helper.email,
+            "password": helper.password,
+            "display_name": display_name,
+        },
+        expected_response_status=HTTPStatus.OK,
+    )
+    token = mock.call_args[1]["token"]
+    helper.validate_email(token=token)
+    return helper.email
+
+
+def _get_display_name_from_db(tdc, email: str) -> str:
+    db_client = tdc.db_client
+    rows = db_client.get_all(User)
+    for row in rows:
+        if row["email"] == email:
+            return row["display_name"]
+    raise AssertionError(f"User with email {email} not found")
+
+
+def test_signup_with_display_name_persists_it(helper):
+    """A display_name supplied at signup should be saved on the created user."""
+    chosen = _unique_display_name("alice")
+    email = _signup_with_display_name(helper, chosen)
+
+    assert _get_display_name_from_db(helper.tdc, email) == chosen
+
+
+def test_signup_without_display_name_defaults_to_padded_user_id(helper):
+    """When no display_name is supplied, default to the user's id (left-padded)."""
+    email = _signup_with_display_name(helper, display_name=None)
+
+    db_client = helper.tdc.db_client
+    user_id = db_client.get_user_id(email=email)
+    assert user_id is not None
+    assert _get_display_name_from_db(helper.tdc, email) == (
+        default_display_name_for_user_id(user_id)
+    )
+
+
+def test_signup_rejects_display_name_too_short(helper):
+    helper.tdc.request_validator.post(
+        endpoint="/auth/signup",
+        json={
+            "email": helper.email,
+            "password": helper.password,
+            "display_name": "ab",
+        },
+        expected_response_status=HTTPStatus.BAD_REQUEST,
+        expected_json_content={"message": DISPLAY_NAME_LENGTH_MESSAGE},
+    )
+
+
+def test_signup_rejects_display_name_too_long(helper):
+    helper.tdc.request_validator.post(
+        endpoint="/auth/signup",
+        json={
+            "email": helper.email,
+            "password": helper.password,
+            "display_name": "x" * 31,
+        },
+        expected_response_status=HTTPStatus.BAD_REQUEST,
+        expected_json_content={"message": DISPLAY_NAME_LENGTH_MESSAGE},
+    )
+
+
+def test_signup_rejects_display_name_with_invalid_characters(helper):
+    helper.tdc.request_validator.post(
+        endpoint="/auth/signup",
+        json={
+            "email": helper.email,
+            "password": helper.password,
+            "display_name": "has space",
+        },
+        expected_response_status=HTTPStatus.BAD_REQUEST,
+        expected_json_content={"message": DISPLAY_NAME_CHARSET_MESSAGE},
+    )
+
+
+def test_signup_rejects_duplicate_display_name_case_insensitive(
+    test_data_creator_flask, mocker
+):
+    """A second signup that requests an existing name (in different casing)
+    should be rejected with a clear conflict message."""
+    helper_a = SignupTestHelper(test_data_creator_flask, mocker)
+    chosen = _unique_display_name("Bob")
+    _signup_with_display_name(helper_a, chosen)
+
+    helper_b = SignupTestHelper(test_data_creator_flask, mocker)
+    helper_b.tdc.request_validator.post(
+        endpoint="/auth/signup",
+        json={
+            "email": helper_b.email,
+            "password": helper_b.password,
+            "display_name": chosen.upper(),
+        },
+        expected_response_status=HTTPStatus.CONFLICT,
+        expected_json_content={"message": DISPLAY_NAME_DUPLICATE_MESSAGE},
+    )
+
+
+def test_patch_updates_display_name(test_data_creator_flask):
+    tdc = test_data_creator_flask
+    tus = tdc.standard_user()
+
+    new_name = _unique_display_name("renamed")
+    tdc.request_validator.patch(
+        endpoint=f"/user/{tus.user_id}",
+        headers=tus.jwt_authorization_header,
+        json={"display_name": new_name},
+    )
+
+    assert _get_display_name_from_db(tdc, tus.user_info.email) == new_name
+
+
+def test_patch_rejects_display_name_too_short(test_data_creator_flask):
+    tdc = test_data_creator_flask
+    tus = tdc.standard_user()
+
+    tdc.request_validator.patch(
+        endpoint=f"/user/{tus.user_id}",
+        headers=tus.jwt_authorization_header,
+        json={"display_name": "ab"},
+        expected_response_status=HTTPStatus.BAD_REQUEST,
+        expected_json_content={"message": DISPLAY_NAME_LENGTH_MESSAGE},
+    )
+
+
+def test_patch_rejects_display_name_with_invalid_characters(test_data_creator_flask):
+    tdc = test_data_creator_flask
+    tus = tdc.standard_user()
+
+    tdc.request_validator.patch(
+        endpoint=f"/user/{tus.user_id}",
+        headers=tus.jwt_authorization_header,
+        json={"display_name": "no spaces!"},
+        expected_response_status=HTTPStatus.BAD_REQUEST,
+        expected_json_content={"message": DISPLAY_NAME_CHARSET_MESSAGE},
+    )
+
+
+def test_patch_rejects_duplicate_display_name_case_insensitive(test_data_creator_flask):
+    tdc = test_data_creator_flask
+    user_a = tdc.standard_user()
+    user_b = tdc.standard_user()
+
+    chosen = _unique_display_name("taken")
+    tdc.request_validator.patch(
+        endpoint=f"/user/{user_a.user_id}",
+        headers=user_a.jwt_authorization_header,
+        json={"display_name": chosen},
+    )
+
+    tdc.request_validator.patch(
+        endpoint=f"/user/{user_b.user_id}",
+        headers=user_b.jwt_authorization_header,
+        json={"display_name": chosen.upper()},
+        expected_response_status=HTTPStatus.CONFLICT,
+        expected_json_content={"message": DISPLAY_NAME_DUPLICATE_MESSAGE},
+    )
+
+
+def test_patch_allows_setting_same_display_name_idempotently(test_data_creator_flask):
+    """Patching a user with the value they already have should not error."""
+    tdc = test_data_creator_flask
+    tus = tdc.standard_user()
+
+    chosen = _unique_display_name("self")
+    tdc.request_validator.patch(
+        endpoint=f"/user/{tus.user_id}",
+        headers=tus.jwt_authorization_header,
+        json={"display_name": chosen},
+    )
+    # Repeat with the same value.
+    tdc.request_validator.patch(
+        endpoint=f"/user/{tus.user_id}",
+        headers=tus.jwt_authorization_header,
+        json={"display_name": chosen},
+    )
+
+    assert _get_display_name_from_db(tdc, tus.user_info.email) == chosen
+
+
+def test_user_profile_response_includes_display_name(test_data_creator_flask):
+    tdc = test_data_creator_flask
+    tus = tdc.standard_user()
+
+    response = tdc.request_validator.get(
+        endpoint=f"/user/{tus.user_id}",
+        headers=tus.jwt_authorization_header,
+    )
+    payload = response["data"] if "data" in response else response
+    assert "display_name" in payload
+    assert isinstance(payload["display_name"], str)
+    assert len(payload["display_name"]) >= 3


### PR DESCRIPTION
Closes #875.

## Summary
- Adds a public, case-insensitive-unique `display_name` field to users.
- Settable at signup, on user creation, and updatable any time by the user via `PATCH /user/{user_id}` (also accessible to admins with `USER_CREATE_UPDATE`).
- Validates length (3-30 chars) and charset (letters, numbers, `-`, `_`) with descriptive error messages, and surfaces a clean conflict message on duplicates.
- Defaults to the user's numeric id (left-padded to 3 chars, e.g. user `7` -> `"007"`) when none is provided. Padding ensures existing users with id < 100 still satisfy the 3-char minimum.
- Included in both `GET /user/{user_id}` (v2 + v3) responses.

## Migration
`alembic/versions/c4a3f8e1d75b_add_user_display_name.py`:
- Adds `users.display_name VARCHAR(30) NOT NULL`, backfills existing rows with `LPAD(id::text, 3, '0')`, and creates a unique functional index on `LOWER(display_name)` (CITEXT-equivalent without the extension).
- Adds nullable `pending_users.display_name` so the chosen handle can be carried through the email-validation step.

## Tests added (`tests/integration/user/display_name/test_display_name.py`)
- `test_signup_with_display_name_persists_it`
- `test_signup_without_display_name_defaults_to_padded_user_id`
- `test_signup_rejects_display_name_too_short`
- `test_signup_rejects_display_name_too_long`
- `test_signup_rejects_display_name_with_invalid_characters`
- `test_signup_rejects_duplicate_display_name_case_insensitive`
- `test_patch_updates_display_name`
- `test_patch_rejects_display_name_too_short`
- `test_patch_rejects_display_name_with_invalid_characters`
- `test_patch_rejects_duplicate_display_name_case_insensitive`
- `test_patch_allows_setting_same_display_name_idempotently`
- `test_user_profile_response_includes_display_name`

## Follow-ups deferred (per the issue)
- Storing past display names (history table).
- Rate-limiting display-name changes to once per 7 days.

## Test plan
- [x] `uv run pytest tests/integration/user tests/integration/auth tests/integration/oauth` (47 passed)
- [x] `uv run pytest tests` (282 passed)
- [x] `uv run ruff check .`
- [x] `uv run basedpyright --level error` (0 errors)
- [x] Migration up/down/up cycle verified locally